### PR TITLE
Manage global state and navigation in BaseActivity

### DIFF
--- a/src/main/kotlin/com/email/IHostActivity.kt
+++ b/src/main/kotlin/com/email/IHostActivity.kt
@@ -1,12 +1,14 @@
 package com.email
 
 import android.view.MenuItem
+import com.email.scenes.params.SceneParams
 
 /**
  * Created by sebas on 1/29/18.
  */
 interface IHostActivity {
     fun refreshToolbarItems()
+    fun goToScene(params: SceneParams)
 
     interface IActivityMenu {
         fun findItemById(id: Int): MenuItem?

--- a/src/main/kotlin/com/email/MailboxActivity.kt
+++ b/src/main/kotlin/com/email/MailboxActivity.kt
@@ -1,10 +1,8 @@
 package com.email
 
-import android.support.design.widget.NavigationView
 import android.view.ViewGroup
 import com.email.DB.FeedLocalDB
 import com.email.DB.MailboxLocalDB
-import com.email.DB.models.FeedItem
 import com.email.scenes.SceneController
 import com.email.scenes.mailbox.*
 import com.email.scenes.mailbox.feed.data.ActivityFeedItem
@@ -20,25 +18,34 @@ import com.email.utils.VirtualList
  * Created by sebas on 1/30/18.
  */
 
-class MailboxActivity : BaseActivity(), IHostActivity {
+class MailboxActivity : BaseActivity() {
     override val layoutId = R.layout.activity_mailbox
     override val toolbarId = R.id.mailbox_toolbar
 
-    override fun initController(): SceneController {
+    override fun initController(receivedModel: Any): SceneController {
         val DB: MailboxLocalDB.Default = MailboxLocalDB.Default(this.applicationContext)
-        val model = MailboxSceneModel()
-        val feedModel = FeedModel()
+        val model = receivedModel as MailboxSceneModel
+        val feedModel = model.feedModel
+
         val rootView = findViewById<ViewGroup>(R.id.drawer_layout)
-        val scene = MailboxScene.MailboxSceneView(rootView, this,
-                VirtualEmailThreadList(model.threads))
-        val feedScene = DrawerFeedView(VirtualFeedList(feedModel.feedItems),
-                findViewById<NavigationView>(R.id.nav_right_view))
+        val scene = MailboxScene.MailboxSceneView(
+                mailboxView = rootView,
+                hostActivity = this,
+                threadList = VirtualEmailThreadList(model.threads)
+        )
+        val feedScene = DrawerFeedView(
+                feedItemsList = VirtualList.Map(feedModel.feedItems, { t -> ActivityFeedItem(t)}),
+                navigationView = findViewById(R.id.nav_right_view)
+        )
+
         return MailboxSceneController(
                 scene = scene,
                 model = model,
+                host = this,
                 dataSource = MailboxDataSource(DB),
                 feedController = initFeedController(feedModel),
-                feedScene = feedScene)
+                feedScene = feedScene
+        )
     }
 
     private fun initFeedController(feedModel: FeedModel): FeedController{
@@ -53,17 +60,6 @@ class MailboxActivity : BaseActivity(), IHostActivity {
 
         override val size: Int
             get() = threads.size
-    }
-
-    private class VirtualFeedList(val feedItems: ArrayList<FeedItem>)
-        : VirtualList<ActivityFeedItem> {
-
-        override fun get(i: Int): ActivityFeedItem {
-            return ActivityFeedItem(feedItems[i])
-        }
-
-        override val size: Int
-            get() = feedItems.size
     }
 
     override fun refreshToolbarItems() {

--- a/src/main/kotlin/com/email/SearchActivity.kt
+++ b/src/main/kotlin/com/email/SearchActivity.kt
@@ -1,9 +1,5 @@
 package com.email
 
-import android.content.Context
-import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
-import android.view.ViewGroup
 import com.email.DB.SearchLocalDB
 import com.email.scenes.SceneController
 import com.email.scenes.search.SearchScene
@@ -12,7 +8,6 @@ import com.email.scenes.search.data.SearchDataSource
 import com.email.scenes.search.data.SearchResult
 import com.email.scenes.search.holders.SearchSceneController
 import com.email.utils.VirtualList
-import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper
 
 /**
  * Created by danieltigse on 2/2/18.
@@ -23,9 +18,9 @@ class SearchActivity : BaseActivity() {
     override val layoutId = R.layout.search_layout
     override val toolbarId = R.id.mailbox_toolbar
 
-    override fun initController(): SceneController {
+    override fun initController(receivedModel: Any): SceneController {
         val DB : SearchLocalDB.Default = SearchLocalDB.Default(this.applicationContext)
-        val model = SearchSceneModel()
+        val model = receivedModel as SearchSceneModel
         val scene = SearchScene.SearchSceneView(this, VirtualSearchList(model.results))
         return SearchSceneController(
                 scene,
@@ -40,5 +35,4 @@ class SearchActivity : BaseActivity() {
         override val size: Int
             get() = results.size
     }
-
 }

--- a/src/main/kotlin/com/email/scenes/SceneController.kt
+++ b/src/main/kotlin/com/email/scenes/SceneController.kt
@@ -1,17 +1,41 @@
 package com.email.scenes
 
 /**
+ * Base class for all the main controllers.
  * Created by sebas on 1/30/18.
  */
 abstract class SceneController {
+    /**
+     * Host activity will check this value every time it has to redraw the toolbar's menu. You
+     * should return the resource id of the menu you wish to display.
+     */
     abstract val menuResourceId: Int?
 
+    /**
+     * Called during the host activity's `onStart()`. This where your controller's "setup" code
+     * should go.
+     */
     abstract fun onStart()
 
+    /**
+     * Called during the host activity's `onStop()`. This where your controller's "teardown" code
+     * should go.
+     */
     abstract fun onStop()
 
+    /**
+     * Called during the host activity's `onBackPressed`. If this function returns true, host
+     * activity with call `super.onBackPressed()`, potentially closing the activity.
+     *
+     * If you don't want your host activity to be closed after the user presses back, make this
+     * function return false.
+     */
     abstract fun onBackPressed(): Boolean
 
+    /**
+     * Called during the host activity's onOptionsItemSelected. You only get the selected item's
+     * id number, to avoid coupling the controller code with android APIs.
+     */
     abstract fun onOptionsItemSelected(itemId: Int)
 
 }

--- a/src/main/kotlin/com/email/scenes/mailbox/MailboxScene.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/MailboxScene.kt
@@ -1,6 +1,5 @@
 package com.email.scenes.mailbox
 
-import android.content.Intent
 import android.support.design.widget.NavigationView
 import android.support.v4.view.GravityCompat
 import android.support.v4.widget.DrawerLayout
@@ -10,18 +9,13 @@ import android.view.View
 import android.view.*
 import android.widget.ImageView
 import com.email.IHostActivity
-import com.email.MailboxActivity
 import com.email.R
-import com.email.SearchActivity
 import com.email.androidui.mailthread.ThreadListView
 import com.email.androidui.mailthread.ThreadRecyclerView
 import com.email.scenes.LabelChooser.LabelChooserDialog
 import com.email.scenes.LabelChooser.LabelDataSourceHandler
-import com.email.scenes.mailbox.feed.data.ActivityFeedItem
 import com.email.scenes.mailbox.data.EmailThread
-import com.email.scenes.mailbox.feed.ui.FeedItemHolder
 import com.email.scenes.mailbox.holders.ToolbarHolder
-import com.email.scenes.mailbox.ui.DrawerFeedView
 import com.email.scenes.mailbox.ui.DrawerMenuView
 import com.email.scenes.mailbox.ui.EmailThreadAdapter
 import com.email.utils.VirtualList
@@ -42,8 +36,7 @@ interface MailboxScene: ThreadListView {
     fun updateToolbarTitle(title: String)
     fun showDialogLabelsChooser(labelDataSourceHandler: LabelDataSourceHandler)
     fun showDialogMoveTo(onMoveThreadsListener: OnMoveThreadsListener)
-    fun openSearchActivity()
-    fun openFeedActivity()
+    fun openNotificationFeed()
 
     class MailboxSceneView(private val mailboxView: View,
                            val hostActivity: IHostActivity,
@@ -55,13 +48,13 @@ interface MailboxScene: ThreadListView {
         private val labelChooserDialog = LabelChooserDialog(context)
         private val moveToDialog = MoveToDialog(context)
 
-        lateinit var drawerMenuView: DrawerMenuView
+        private lateinit var drawerMenuView: DrawerMenuView
 
         private val recyclerView: RecyclerView by lazy {
             mailboxView.findViewById<RecyclerView>(R.id.mailbox_recycler)
         }
 
-        val toolbarHolder: ToolbarHolder by lazy {
+        private val toolbarHolder: ToolbarHolder by lazy {
             val view = mailboxView.findViewById<Toolbar>(R.id.mailbox_toolbar)
             ToolbarHolder(view)
         }
@@ -80,7 +73,7 @@ interface MailboxScene: ThreadListView {
 
         private lateinit var threadRecyclerView: ThreadRecyclerView
 
-        var threadListener: EmailThreadAdapter.OnThreadEventListener? = null
+        private var threadListener: EmailThreadAdapter.OnThreadEventListener? = null
             set(value) {
                 threadRecyclerView.setThreadListener(value)
                 field = value
@@ -158,12 +151,7 @@ interface MailboxScene: ThreadListView {
             labelChooserDialog.showDialogLabelsChooser(dataSource = labelDataSourceHandler)
         }
 
-        override fun openSearchActivity(){
-            (hostActivity as MailboxActivity).startActivity(Intent(hostActivity, SearchActivity::class.java))
-            hostActivity.overridePendingTransition(0,0)
-        }
-
-        override fun openFeedActivity(){
+        override fun openNotificationFeed(){
             drawerLayout.openDrawer(GravityCompat.END)
         }
 

--- a/src/main/kotlin/com/email/scenes/mailbox/MailboxSceneController.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/MailboxSceneController.kt
@@ -2,6 +2,7 @@ package com.email.scenes.mailbox
 
 import com.email.androidui.mailthread.ThreadListController
 import android.content.Context
+import com.email.IHostActivity
 import com.email.R
 import com.email.scenes.LabelChooser.LabelDataSourceHandler
 import com.email.scenes.LabelChooser.SelectedLabels
@@ -12,12 +13,14 @@ import com.email.scenes.mailbox.data.MailboxDataSource
 import com.email.scenes.mailbox.feed.FeedController
 import com.email.scenes.mailbox.ui.EmailThreadAdapter
 import com.email.scenes.mailbox.ui.DrawerFeedView
+import com.email.scenes.params.SearchParams
 
 /**
  * Created by sebas on 1/30/18.
  */
 class MailboxSceneController(private val scene: MailboxScene,
                              private val model: MailboxSceneModel,
+                             private val host: IHostActivity,
                              private val dataSource: MailboxDataSource,
                              private val feedController : FeedController,
                              private val feedScene: DrawerFeedView) : SceneController() {
@@ -95,7 +98,7 @@ class MailboxSceneController(private val scene: MailboxScene,
 
     }
 
-    fun archiveSelectedEmailThreads() {
+    private fun archiveSelectedEmailThreads() {
         val emailThreads = model.selectedThreads.toList()
         emailThreads.forEach {
             dataSource.removeLabelsRelation(it.labelsOfMail, it.id)
@@ -106,7 +109,8 @@ class MailboxSceneController(private val scene: MailboxScene,
         threadListController.setThreadList(fetchEmailThreads)
         scene.notifyThreadSetChanged()
     }
-    fun deleteSelectedEmailThreads() {
+
+    private fun deleteSelectedEmailThreads() {
         val emailThreads = model.selectedThreads.toList()
         dataSource.deleteEmailThreads(emailThreads)
 
@@ -117,7 +121,7 @@ class MailboxSceneController(private val scene: MailboxScene,
         scene.notifyThreadSetChanged()
     }
 
-    fun toggleReadSelectedEmailThreads(title: String) {
+    private fun toggleReadSelectedEmailThreads(title: String) {
         val unreadStatus = (title != "read")
         val emailThreads = model.selectedThreads.toList()
             dataSource.updateUnreadStatus(emailThreads = emailThreads,
@@ -130,14 +134,15 @@ class MailboxSceneController(private val scene: MailboxScene,
         scene.notifyThreadSetChanged()
     }
 
-    fun showMultiModeBar() {
+    private fun showMultiModeBar() {
         val selectedThreadsQuantity : Int = model.selectedThreads.length()
         scene.showMultiModeBar(selectedThreadsQuantity)
     }
 
-    fun hideMultiModeBar() {
+    private fun hideMultiModeBar() {
         scene.hideMultiModeBar()
     }
+
     override fun onBackPressed(): Boolean {
         return scene.onBackPressed()
     }
@@ -152,27 +157,15 @@ class MailboxSceneController(private val scene: MailboxScene,
 
     override fun onOptionsItemSelected(itemId: Int) {
         when(itemId) {
-            R.id.mailbox_search -> {
-                scene.openSearchActivity()
-            }
-            R.id.mailbox_bell_container -> {
-                scene.openFeedActivity()
-            }
-            R.id.mailbox_archive_selected_messages -> {
-                archiveSelectedEmailThreads()
-            }
-            R.id.mailbox_delete_selected_messages -> {
-                deleteSelectedEmailThreads()
-            }
-            R.id.mailbox_message_toggle_read -> {
-                toggleReadSelectedEmailThreads("READ")
-            }
-            R.id.mailbox_move_to -> {
+            R.id.mailbox_search -> host.goToScene(SearchParams())
+            R.id.mailbox_bell_container -> scene.openNotificationFeed()
+            R.id.mailbox_archive_selected_messages -> archiveSelectedEmailThreads()
+            R.id.mailbox_delete_selected_messages -> deleteSelectedEmailThreads()
+            R.id.mailbox_message_toggle_read -> toggleReadSelectedEmailThreads("READ")
+            R.id.mailbox_move_to ->
                 scene.showDialogMoveTo(OnMoveThreadsListener(this))
-            }
-            R.id.mailbox_add_labels ->{
+            R.id.mailbox_add_labels ->
                 scene.showDialogLabelsChooser(LabelDataSourceHandler(this))
-            }
         }
     }
 

--- a/src/main/kotlin/com/email/scenes/mailbox/MailboxSceneModel.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/MailboxSceneModel.kt
@@ -2,6 +2,7 @@ package com.email.scenes.mailbox
 
 import com.email.scenes.SceneModel
 import com.email.scenes.mailbox.data.EmailThread
+import com.email.scenes.mailbox.feed.FeedModel
 import com.email.scenes.mailbox.feed.data.ActivityFeedItem
 
 /**
@@ -18,4 +19,5 @@ class MailboxSceneModel : SceneModel {
     val selectedThreads = SelectedThreads()
     val hasSelectedUnreadMessages: Boolean
         get() = selectedThreads.hasUnreadThreads
+    val feedModel = FeedModel()
 }

--- a/src/main/kotlin/com/email/scenes/mailbox/ui/EmailThreadAdapter.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/ui/EmailThreadAdapter.kt
@@ -13,9 +13,9 @@ import com.email.utils.VirtualList
  * Created by sebas on 1/23/18.
  */
 
-class EmailThreadAdapter(val mContext : Context,
+class EmailThreadAdapter(private val mContext : Context,
                          var threadListener : OnThreadEventListener?,
-                         val threadList: VirtualList<EmailThread>)
+                         private val threadList: VirtualList<EmailThread>)
     : RecyclerView.Adapter<EmailHolder>() {
 
     var isMultiSelectMode = false

--- a/src/main/kotlin/com/email/scenes/params/ComposerParams.kt
+++ b/src/main/kotlin/com/email/scenes/params/ComposerParams.kt
@@ -1,0 +1,9 @@
+package com.email.scenes.params
+
+/**
+ * Created by gabriel on 2/15/18.
+ */
+
+sealed class ComposerParams {
+
+}

--- a/src/main/kotlin/com/email/scenes/params/SceneParams.kt
+++ b/src/main/kotlin/com/email/scenes/params/SceneParams.kt
@@ -1,0 +1,10 @@
+package com.email.scenes.params
+
+/**
+ * Struct used to contain data needed as "ingredients" for new models.
+ * Created by gabriel on 2/15/18.
+ */
+
+abstract class SceneParams {
+    abstract val activityClass: Class<*>
+}

--- a/src/main/kotlin/com/email/scenes/params/SearchParams.kt
+++ b/src/main/kotlin/com/email/scenes/params/SearchParams.kt
@@ -1,0 +1,11 @@
+package com.email.scenes.params
+
+import com.email.SearchActivity
+
+/**
+ * Created by gabriel on 2/15/18.
+ */
+
+class SearchParams: SceneParams() {
+    override val activityClass = SearchActivity::class.java
+}

--- a/src/main/kotlin/com/email/utils/VirtualList.kt
+++ b/src/main/kotlin/com/email/utils/VirtualList.kt
@@ -4,8 +4,16 @@ package com.email.utils
  * Created by gabriel on 2/9/18.
  */
 
-interface VirtualList<out T> {
-    operator fun get(i: Int): T
+interface VirtualList<out U> {
+    operator fun get(i: Int): U
 
     val size: Int
+
+    class Map<T, out U> (private val originalItems: List<T>,
+                         private val mapFn: (T) -> U): VirtualList<U> {
+        override operator fun get(i: Int): U = mapFn(originalItems[i])
+
+        override val size: Int
+            get () = originalItems.size
+}
 }


### PR DESCRIPTION
Keep global state in a private companion object of BaseActivity. For
now, only use a HashMap to store Models using its host activity as key.
BaseActivity will update this HashMap whenever a controller requests to
go to a different scene.

Add new method to IHostActivity: `goToScene` which receives a params
object which BaseActivity will use to create the new model along with
the new activity. Since BaseActivity now creates the models and keeps
references in the global state, the `initController` function now
receives the model as parameter.