### PR TITLE
Write android test exchanging messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ dependencies {
 
     // Kluent
     testImplementation 'org.amshove.kluent:kluent:1.34'
+    androidTestImplementation 'org.amshove.kluent:kluent-android:1.34'
 
     // Support v4
     implementation 'com.android.support:support-v4:26.1.0'

--- a/src/androidTest/kotlin/com/email/activity/DeckardEspressoTest.kt
+++ b/src/androidTest/kotlin/com/email/activity/DeckardEspressoTest.kt
@@ -12,6 +12,7 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.runner.AndroidJUnit4
+import com.email.splash.SplashActivity
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -19,7 +20,7 @@ class DeckardEspressoTest {
 
 
     @get:Rule
-    val mActivityRule = ActivityTestRule(DeckardActivity::class.java)
+    val mActivityRule = ActivityTestRule(SplashActivity::class.java)
 
     @Test
     @Throws(InterruptedException::class)

--- a/src/androidTest/kotlin/com/email/signal/InMemoryUser.kt
+++ b/src/androidTest/kotlin/com/email/signal/InMemoryUser.kt
@@ -1,0 +1,61 @@
+package com.email.signal
+
+import com.email.db.models.signal.CRPreKey
+import org.whispersystems.libsignal.IdentityKeyPair
+import org.whispersystems.libsignal.state.PreKeyRecord
+import org.whispersystems.libsignal.state.SignedPreKeyRecord
+import org.whispersystems.libsignal.state.impl.InMemorySignalProtocolStore
+
+/**
+ * Created by gabriel on 3/17/18.
+ */
+class InMemoryUser(recipientId: String, deviceId: Int) {
+        private val generator = SignalKeyGenerator.Default()
+        private val registrationBundles = generator.register(recipientId, deviceId)
+        private val store = createStoreFromRegistrationBundle(registrationBundles)
+        private val client = SignalClient.Default(store)
+
+        init {
+            val privateBundle = registrationBundles.privateBundle
+            // insert pre keys
+            privateBundle.preKeys.forEach { id, byteString ->
+                val preKey = PreKeyRecord(Encoding.stringToByteArray(byteString))
+                store.storePreKey(id, preKey)
+            }
+
+            // insert signed pre key
+            val signedPreKeyRecord = SignedPreKeyRecord(
+                    Encoding.stringToByteArray(privateBundle.signedPreKey))
+            store.storeSignedPreKey(privateBundle.signedPreKeyId, signedPreKeyRecord)
+        }
+
+        fun fetchAPreKeyBundle(): PreKeyBundleShareData.DownloadBundle {
+            val bundle = registrationBundles.uploadBundle
+            val preKeyPublic = bundle.preKeys[0]!!
+            val preKeyRecord = CRPreKey(0, preKeyPublic)
+
+            return PreKeyBundleShareData.DownloadBundle(
+                    shareData = registrationBundles.uploadBundle.shareData,
+                    preKey = preKeyRecord)
+        }
+
+        fun buildSession(downloadBundle: PreKeyBundleShareData.DownloadBundle) {
+            client.createSessionsFromBundles(listOf(downloadBundle))
+        }
+
+        fun encrypt(recipientId: String, deviceId: Int, text: String) =
+            client.encryptMessage(recipientId, deviceId, text)
+
+        fun decrypt(recipientId: String, deviceId: Int, text: String) =
+                client.decryptMessage(recipientId, deviceId, text)
+
+        private companion object {
+            fun createStoreFromRegistrationBundle(registrationBundles: SignalKeyGenerator.RegistrationBundles)
+                    : InMemorySignalProtocolStore {
+                val privateBundle = registrationBundles.privateBundle
+                val identityKeyPairBytes = Encoding.stringToByteArray(privateBundle.identityKeyPair)
+                val identityKeyPair = IdentityKeyPair(identityKeyPairBytes)
+                return InMemorySignalProtocolStore(identityKeyPair, privateBundle.registrationId)
+            }
+        }
+    }

--- a/src/androidTest/kotlin/com/email/signal/LocalCommunicationTest.kt
+++ b/src/androidTest/kotlin/com/email/signal/LocalCommunicationTest.kt
@@ -1,0 +1,39 @@
+package com.email.signal
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.email.splash.SplashActivity
+import org.amshove.kluent.shouldEqual
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Created by gabriel on 3/16/18.
+ */
+@RunWith(AndroidJUnit4::class)
+class LocalCommunicationTest {
+
+    @get:Rule
+    val mActivityRule = ActivityTestRule(SplashActivity::class.java)
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun should_be_able_to_exchange_e2e_messages_in_memory_with_signal() {
+        val alice = InMemoryUser("alice", 1)
+        val bob = InMemoryUser("bob", 1)
+
+        val keyBundleFromBob = bob.fetchAPreKeyBundle()
+        alice.buildSession(keyBundleFromBob)
+
+        val originalTextFromAlice = "Hello Bob! How are you! I'm using Criptext. This is my 1st e-mail."
+        val textEncryptedByAlice = alice.encrypt("bob", 1, originalTextFromAlice)
+
+        val textDecryptedByBob = bob.decrypt("alice", 1, textEncryptedByAlice)
+        textDecryptedByBob shouldEqual originalTextFromAlice
+    }
+
+
+
+
+}

--- a/src/main/kotlin/com/email/signal/PreKeyBundleShareData.kt
+++ b/src/main/kotlin/com/email/signal/PreKeyBundleShareData.kt
@@ -3,6 +3,7 @@ package com.email.signal
 import com.email.db.models.signal.CRPreKey
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.*
 
 /**
  * Created by gabriel on 11/10/17.
@@ -45,15 +46,24 @@ data class PreKeyBundleShareData(val recipientId: String,
 
                 return DownloadBundle(shareData = shareData, preKey = preKey)
             }
+
+            fun fromJSONArray(jsonArray: JSONArray): List<DownloadBundle> {
+                val length = jsonArray.length()
+                return (0..(length-1))
+                        .map {
+                            val json = jsonArray.getJSONObject(it)
+                            fromJSON(json)
+                        }
+            }
         }
 }
 
-    data class UploadBundle(private val shareData: PreKeyBundleShareData,
-                            private val serializedPreKeys: Map<Int, String>
+    data class UploadBundle(val shareData: PreKeyBundleShareData,
+                            val preKeys: Map<Int, String>
     ) {
         fun toJSON(): JSONObject {
             val preKeyArray = JSONArray()
-            serializedPreKeys.forEach { (id, key) ->
+            preKeys.forEach { (id, key) ->
                 val item = JSONObject()
                 item.put("id", id)
                 item.put("publicKey", key)

--- a/src/main/kotlin/com/email/signal/SignalClient.kt
+++ b/src/main/kotlin/com/email/signal/SignalClient.kt
@@ -1,0 +1,102 @@
+package com.email.signal
+
+import android.util.Log
+import org.whispersystems.libsignal.IdentityKey
+import org.whispersystems.libsignal.SessionBuilder
+import org.whispersystems.libsignal.SessionCipher
+import org.whispersystems.libsignal.SignalProtocolAddress
+import org.whispersystems.libsignal.ecc.Curve
+import org.whispersystems.libsignal.protocol.PreKeySignalMessage
+import org.whispersystems.libsignal.state.PreKeyBundle
+import org.whispersystems.libsignal.state.SignalProtocolStore
+import java.nio.charset.Charset
+
+/**
+ * Created by gabriel on 3/16/18.
+ */
+interface SignalClient {
+    /**
+     * Takes a list of keybundles and creates new sessions. with each
+     */
+    fun  createSessionsFromBundles(bundles: List<PreKeyBundleShareData.DownloadBundle>)
+
+    /**
+     * encrypts a message using Signal.
+     * @param recipientId the username of the only Criptext user that can decrypt this message
+     * @param deviceId The id of the only device owned by `recipientId` that can decrypt this
+     * message. Make sure that you have already established a session with this recipientId + deviceId.
+     * @param plainText A plain message to encrypt, encoded in UTF-8.
+     * @returns A Base64 string with the encrypted bytes.
+     */
+    fun encryptMessage(recipientId: String, deviceId: Int, plainText: String): String
+
+    /**
+     * decrypts a message using Signal.
+     * @param recipientId the username of the Criptext user that encrypted this message
+     * @param deviceId The id of the device owned by `recipientId` that encrypted this
+     * message.
+     * @param encryptedB64 A Base64 string with the encrypted bytes.
+     * @returns The original UTF-8 plain text message.
+     */
+    fun decryptMessage(recipientId: String, deviceId: Int, encryptedB64: String): String
+
+    class Default(private val store: SignalProtocolStore) : SignalClient {
+        private val createNewSessionParams: (PreKeyBundleShareData.DownloadBundle) -> NewSessionParams =
+            { downloadBundle ->
+                val shareData = downloadBundle.shareData
+                val registrationId = shareData.registrationId
+                val deviceId = shareData.deviceId
+                val preKeyId = downloadBundle.preKey?.id ?: 0
+                val publicPreKeyString = downloadBundle.preKey?.byteString
+                val signedPreKeyId = shareData.signedPreKeyId
+                val signedPreKeyPublicString = shareData.signedPreKeyPublic
+                val signedPreKeySignatureString = shareData.signedPreKeySignature
+                val identityPublicKeyString = shareData.identityPublicKey
+
+                val publicPreKeyBytes = if (publicPreKeyString != null)
+                                            Encoding.stringToByteArray(publicPreKeyString)
+                                        else null
+                val publicPreKey = Curve.decodePoint(publicPreKeyBytes, 0)
+
+                val signedPreKeyPublicBytes = Encoding.stringToByteArray(signedPreKeyPublicString)
+                val signedPreKeyPublic = Curve.decodePoint(signedPreKeyPublicBytes, 0)
+
+                val signedPreKeySignature = Encoding.stringToByteArray(signedPreKeySignatureString)
+
+                val identityPublicKeyBytes = Encoding.stringToByteArray(identityPublicKeyString)
+                val identityPublicKey = IdentityKey(identityPublicKeyBytes, 0)
+
+                val preKeyBundle = PreKeyBundle(registrationId, deviceId, preKeyId, publicPreKey,
+                                   signedPreKeyId, signedPreKeyPublic, signedPreKeySignature,
+                                   identityPublicKey)
+                NewSessionParams(recipientId = downloadBundle.shareData.recipientId,
+                               preKeyBundle = preKeyBundle)
+            }
+
+        private val buildNewSession: (NewSessionParams) -> Unit = { params ->
+            val sessionBuilder = SessionBuilder(store, SignalProtocolAddress(params.recipientId,
+                    params.preKeyBundle.deviceId))
+            sessionBuilder.process(params.preKeyBundle)
+        }
+
+        override fun createSessionsFromBundles(bundles: List<PreKeyBundleShareData.DownloadBundle>) {
+            bundles.map(createNewSessionParams).forEach(buildNewSession)
+        }
+
+        override fun encryptMessage(recipientId: String, deviceId: Int, plainText: String): String {
+            val cipher = SessionCipher(store, SignalProtocolAddress(recipientId, deviceId))
+            val cipherText = cipher.encrypt(plainText.toByteArray(Charset.forName("UTF-8")))
+            return Encoding.byteArrayToString(cipherText.serialize())
+        }
+
+        override fun decryptMessage(recipientId: String, deviceId: Int, encryptedB64: String): String {
+            val encryptedBytes = Encoding.stringToByteArray(encryptedB64)
+            val signalMessage = PreKeySignalMessage(encryptedBytes)
+            val cipher = SessionCipher(store, SignalProtocolAddress(recipientId, deviceId))
+            return cipher.decrypt(signalMessage).toString(Charset.forName("UTF-8"))
+        }
+
+    }
+
+    private data class NewSessionParams(val recipientId: String, val preKeyBundle: PreKeyBundle)
+}

--- a/src/test/java/com/email/mocks/MockedSignalKeyGenerator.kt
+++ b/src/test/java/com/email/mocks/MockedSignalKeyGenerator.kt
@@ -2,13 +2,12 @@ package com.email.mocks
 
 import com.email.signal.PreKeyBundleShareData
 import com.email.signal.SignalKeyGenerator
-import org.whispersystems.libsignal.state.PreKeyRecord
 
 /**
  * Created by sebas on 3/6/18.
  */
 
-class MockedSignalKeyGenerator: SignalKeyGenerator {
+class MockedSignalKeyGenerator : SignalKeyGenerator {
     override fun register(recipientId: String, deviceId: Int): SignalKeyGenerator.RegistrationBundles {
         val shareData = PreKeyBundleShareData(
                 deviceId = deviceId,

--- a/src/test/java/com/email/scenes/signup/mocks/MockedSignUpLocalDB.kt
+++ b/src/test/java/com/email/scenes/signup/mocks/MockedSignUpLocalDB.kt
@@ -2,27 +2,19 @@ package com.email.scenes.signup.mocks
 
 import com.email.db.SignUpLocalDB
 import com.email.db.models.Account
-import com.email.db.models.signal.CRSignedPreKey
+import com.email.signal.SignalKeyGenerator
 
 /**
  * Created by sebas on 2/27/18.
  */
 
 class MockedSignUpLocalDB : SignUpLocalDB {
+
     var savedUser: Account? = null
     private set
 
-    override fun deletePrekeys() {
-    }
-
-    override fun storePrekeys(prekeys: Map<Int, String>) {
-    }
-
-    override fun saveAccount(account: Account) {
+    override fun saveNewUserData(account: Account, keyBundle: SignalKeyGenerator.PrivateBundle) {
         savedUser = account
-    }
-
-    override fun storeRawSignedPrekey(crSignedPreKey: CRSignedPreKey) {
     }
 
 }


### PR DESCRIPTION
Create SignalClient class to help encrypting and decrypting
Create InMemoryUser class using signal's InMemorySignalProtocolStore for
easier testing.
Create LocalCommunicationTest which loads 2 users in memory and asserts
that messages can be encrypted and decrypted.