### PR TITLE
Write signal tests with room

### DIFF
--- a/src/androidTest/kotlin/com/email/signal/InDBUser.kt
+++ b/src/androidTest/kotlin/com/email/signal/InDBUser.kt
@@ -1,0 +1,28 @@
+package com.email.signal
+
+import com.email.db.AppDatabase
+import com.email.db.SignUpLocalDB
+import com.email.scenes.signup.IncompleteAccount
+import org.whispersystems.libsignal.state.SignalProtocolStore
+
+/**
+ * Created by gabriel on 3/17/18.
+ */
+
+class InDBUser(private val db: AppDatabase, signUpLocalDB: SignUpLocalDB,
+               generator: SignalKeyGenerator, recipientId: String, deviceId: Int)
+    : TestUser(generator, recipientId, deviceId) {
+
+    override val store: SignalProtocolStore by lazy {
+        SignalStoreCriptext(db)
+    }
+
+    init {
+        val privateBundle = registrationBundles.privateBundle
+        val incompleteAccount = IncompleteAccount(username = recipientId, name = recipientId,
+                password = "12345", recoveryEmail ="support@criptext.com")
+        val persistedUser = incompleteAccount.complete(privateBundle, "jwt")
+        signUpLocalDB.saveNewUserData(persistedUser, privateBundle)
+    }
+
+}

--- a/src/androidTest/kotlin/com/email/signal/InMemoryUser.kt
+++ b/src/androidTest/kotlin/com/email/signal/InMemoryUser.kt
@@ -1,61 +1,40 @@
 package com.email.signal
 
-import com.email.db.models.signal.CRPreKey
 import org.whispersystems.libsignal.IdentityKeyPair
 import org.whispersystems.libsignal.state.PreKeyRecord
+import org.whispersystems.libsignal.state.SignalProtocolStore
 import org.whispersystems.libsignal.state.SignedPreKeyRecord
 import org.whispersystems.libsignal.state.impl.InMemorySignalProtocolStore
 
 /**
  * Created by gabriel on 3/17/18.
  */
-class InMemoryUser(recipientId: String, deviceId: Int) {
-        private val generator = SignalKeyGenerator.Default()
-        private val registrationBundles = generator.register(recipientId, deviceId)
-        private val store = createStoreFromRegistrationBundle(registrationBundles)
-        private val client = SignalClient.Default(store)
+class InMemoryUser(generator: SignalKeyGenerator, recipientId: String, deviceId: Int)
+    : TestUser(generator, recipientId, deviceId) {
 
-        init {
+    override val store: SignalProtocolStore =
+        createStoreFromRegistrationBundle(registrationBundles)
+
+    init {
+        val privateBundle = registrationBundles.privateBundle
+        // insert pre keys
+        privateBundle.preKeys.forEach { id, byteString ->
+            val preKey = PreKeyRecord(Encoding.stringToByteArray(byteString))
+            store.storePreKey(id, preKey)
+        }
+
+        // insert signed pre key
+        val signedPreKeyRecord = SignedPreKeyRecord(
+                Encoding.stringToByteArray(privateBundle.signedPreKey))
+        store.storeSignedPreKey(privateBundle.signedPreKeyId, signedPreKeyRecord)
+    }
+    private companion object {
+        fun createStoreFromRegistrationBundle(registrationBundles: SignalKeyGenerator.RegistrationBundles)
+                : InMemorySignalProtocolStore {
             val privateBundle = registrationBundles.privateBundle
-            // insert pre keys
-            privateBundle.preKeys.forEach { id, byteString ->
-                val preKey = PreKeyRecord(Encoding.stringToByteArray(byteString))
-                store.storePreKey(id, preKey)
-            }
-
-            // insert signed pre key
-            val signedPreKeyRecord = SignedPreKeyRecord(
-                    Encoding.stringToByteArray(privateBundle.signedPreKey))
-            store.storeSignedPreKey(privateBundle.signedPreKeyId, signedPreKeyRecord)
-        }
-
-        fun fetchAPreKeyBundle(): PreKeyBundleShareData.DownloadBundle {
-            val bundle = registrationBundles.uploadBundle
-            val preKeyPublic = bundle.preKeys[0]!!
-            val preKeyRecord = CRPreKey(0, preKeyPublic)
-
-            return PreKeyBundleShareData.DownloadBundle(
-                    shareData = registrationBundles.uploadBundle.shareData,
-                    preKey = preKeyRecord)
-        }
-
-        fun buildSession(downloadBundle: PreKeyBundleShareData.DownloadBundle) {
-            client.createSessionsFromBundles(listOf(downloadBundle))
-        }
-
-        fun encrypt(recipientId: String, deviceId: Int, text: String) =
-            client.encryptMessage(recipientId, deviceId, text)
-
-        fun decrypt(recipientId: String, deviceId: Int, text: String) =
-                client.decryptMessage(recipientId, deviceId, text)
-
-        private companion object {
-            fun createStoreFromRegistrationBundle(registrationBundles: SignalKeyGenerator.RegistrationBundles)
-                    : InMemorySignalProtocolStore {
-                val privateBundle = registrationBundles.privateBundle
-                val identityKeyPairBytes = Encoding.stringToByteArray(privateBundle.identityKeyPair)
-                val identityKeyPair = IdentityKeyPair(identityKeyPairBytes)
-                return InMemorySignalProtocolStore(identityKeyPair, privateBundle.registrationId)
-            }
+            val identityKeyPairBytes = Encoding.stringToByteArray(privateBundle.identityKeyPair)
+            val identityKeyPair = IdentityKeyPair(identityKeyPairBytes)
+            return InMemorySignalProtocolStore(identityKeyPair, privateBundle.registrationId)
         }
     }
+}

--- a/src/androidTest/kotlin/com/email/signal/LocalCommunicationTest.kt
+++ b/src/androidTest/kotlin/com/email/signal/LocalCommunicationTest.kt
@@ -16,12 +16,13 @@ class LocalCommunicationTest {
 
     @get:Rule
     val mActivityRule = ActivityTestRule(SplashActivity::class.java)
+    private val generator = SignalKeyGenerator.Default()
 
     @Test
     @Throws(InterruptedException::class)
     fun should_be_able_to_exchange_e2e_messages_in_memory_with_signal() {
-        val alice = InMemoryUser("alice", 1)
-        val bob = InMemoryUser("bob", 1)
+        val alice = InMemoryUser(generator, "alice", 1).setup()
+        val bob = InMemoryUser(generator, "bob", 1).setup()
 
         val keyBundleFromBob = bob.fetchAPreKeyBundle()
         alice.buildSession(keyBundleFromBob)

--- a/src/androidTest/kotlin/com/email/signal/LocalPersistentCommunicationTest.kt
+++ b/src/androidTest/kotlin/com/email/signal/LocalPersistentCommunicationTest.kt
@@ -1,0 +1,67 @@
+package com.email.signal
+
+import android.support.test.rule.ActivityTestRule
+import com.email.db.SignUpLocalDB
+import com.email.db.TestDatabase
+import com.email.splash.SplashActivity
+import org.amshove.kluent.shouldEqual
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Created by gabriel on 3/17/18.
+ */
+
+class LocalPersistentCommunicationTest {
+    @get:Rule
+    val mActivityRule = ActivityTestRule(SplashActivity::class.java)
+
+    private val keyGenerator = SignalKeyGenerator.Default()
+    private lateinit var db:  TestDatabase
+    private lateinit var signUpDB: SignUpLocalDB
+
+
+    @Before
+    fun setup() {
+        db = TestDatabase.getAppDatabase(mActivityRule.activity)
+        db.resetDao().deleteAllData(1)
+        signUpDB = SignUpLocalDB.Default(db)
+    }
+
+    private fun newPersistedUser(recipientId: String, deviceId: Int): InDBUser {
+        return InDBUser(db, signUpDB, keyGenerator, recipientId, deviceId)
+    }
+
+    @Test
+    fun should_create_user_in_db_and_send_e2e_message_to_inmemory_user() {
+        val alice = newPersistedUser("alice", 1).setup()
+        val bob = InMemoryUser(keyGenerator, "bob", 1).setup()
+
+        val keyBundleFromBob = bob.fetchAPreKeyBundle()
+        alice.buildSession(keyBundleFromBob)
+
+        val originalTextFromAlice = "Hello Bob! How are you! I'm persisting my data with Room. This is my 1st e-mail."
+        val textEncryptedByAlice = alice.encrypt("bob", 1, originalTextFromAlice)
+
+        val textDecryptedByBob = bob.decrypt("alice", 1, textEncryptedByAlice)
+        textDecryptedByBob shouldEqual originalTextFromAlice
+
+    }
+
+    @Test
+    fun should_create_user_in_db_and_receive_e2e_message_from_inmemory_user() {
+        val alice = newPersistedUser("alice", 1).setup()
+        val bob = InMemoryUser(keyGenerator, "bob", 1).setup()
+
+        val keyBundleFromAlice = alice.fetchAPreKeyBundle()
+        bob.buildSession(keyBundleFromAlice)
+
+        val originalTextFromBob = "Hello Alice! How are you! I'm in ur RAM. This is my 1st e-mail."
+        val textEncryptedByBob = bob.encrypt("alice", 1, originalTextFromBob)
+
+        val textDecryptedByAlice = alice.decrypt("bob", 1, textEncryptedByBob)
+        textDecryptedByAlice shouldEqual originalTextFromBob
+    }
+
+}

--- a/src/androidTest/kotlin/com/email/signal/TestUser.kt
+++ b/src/androidTest/kotlin/com/email/signal/TestUser.kt
@@ -1,0 +1,41 @@
+package com.email.signal
+
+import com.email.db.models.signal.CRPreKey
+import org.whispersystems.libsignal.state.SignalProtocolStore
+
+/**
+ * Created by gabriel on 3/17/18.
+ */
+
+abstract class TestUser(generator: SignalKeyGenerator, recipientId: String, deviceId: Int) {
+
+    val registrationBundles = generator.register(recipientId, deviceId)
+    abstract val store: SignalProtocolStore
+    private lateinit var client: SignalClient
+
+    fun setup(): TestUser {
+        client = SignalClient.Default(store)
+        return this
+    }
+
+    fun fetchAPreKeyBundle(): PreKeyBundleShareData.DownloadBundle {
+        val bundle = registrationBundles.uploadBundle
+        val preKeyPublic = bundle.preKeys[0]!!
+        val preKeyRecord = CRPreKey(0, preKeyPublic)
+
+        return PreKeyBundleShareData.DownloadBundle(
+                shareData = registrationBundles.uploadBundle.shareData,
+                preKey = preKeyRecord)
+    }
+
+    fun buildSession(downloadBundle: PreKeyBundleShareData.DownloadBundle) {
+        client.createSessionsFromBundles(listOf(downloadBundle))
+    }
+
+    fun encrypt(recipientId: String, deviceId: Int, text: String) =
+        client.encryptMessage(recipientId, deviceId, text)
+
+    fun decrypt(recipientId: String, deviceId: Int, text: String) =
+            client.decryptMessage(recipientId, deviceId, text)
+
+}

--- a/src/main/kotlin/com/email/db/SignUpLocalDB.kt
+++ b/src/main/kotlin/com/email/db/SignUpLocalDB.kt
@@ -14,8 +14,9 @@ import com.email.signal.SignalKeyGenerator
 interface SignUpLocalDB {
     fun saveNewUserData(account: Account, keyBundle: SignalKeyGenerator.PrivateBundle)
 
-    class Default(applicationContext: Context): SignUpLocalDB {
-        private val db = AppDatabase.getAppDatabase(applicationContext)
+    class Default(private val db: AppDatabase): SignUpLocalDB {
+
+        constructor(ctx: Context): this (AppDatabase.getAppDatabase(ctx))
 
         private fun storePreKeys(preKeys: Map<Int, String>) {
             val listPreKeys: ArrayList<CRPreKey> = ArrayList()

--- a/src/main/kotlin/com/email/db/TestDatabase.kt
+++ b/src/main/kotlin/com/email/db/TestDatabase.kt
@@ -1,0 +1,52 @@
+package com.email.db
+
+import android.arch.persistence.room.Database
+import android.arch.persistence.room.Room
+import android.arch.persistence.room.RoomDatabase
+import android.arch.persistence.room.TypeConverters
+import android.content.Context
+import com.email.db.TypeConverters.BooleanConverter
+import com.email.db.TypeConverters.DateConverter
+import com.email.db.TypeConverters.LabelColorConverter
+import com.email.db.dao.*
+import com.email.db.dao.signal.RawIdentityKeyDao
+import com.email.db.dao.signal.RawPreKeyDao
+import com.email.db.dao.signal.RawSessionDao
+import com.email.db.dao.signal.RawSignedPreKeyDao
+import com.email.db.models.*
+import com.email.db.models.signal.CRIdentityKey
+import com.email.db.models.signal.CRPreKey
+import com.email.db.models.signal.CRSessionRecord
+import com.email.db.models.signal.CRSignedPreKey
+
+/**
+ * Created by gabriel on 3/17/18.
+ */
+@Database(entities = [ Email::class, Label::class, EmailLabel::class, Account::class, EmailContact::class
+                     , File::class, Open::class, FeedItem::class, CRPreKey::class, Contact::class
+                     , CRSessionRecord::class, CRIdentityKey::class, CRSignedPreKey::class],
+        version = 1,
+        exportSchema = false)
+@TypeConverters(DateConverter::class, BooleanConverter::class, LabelColorConverter::class)
+abstract class TestDatabase : AppDatabase() {
+    abstract fun resetDao(): ResetDao
+
+    companion object {
+        private var INSTANCE : TestDatabase? = null
+
+        fun getAppDatabase(context: Context): TestDatabase {
+            if(INSTANCE == null){
+                INSTANCE = Room.databaseBuilder(context,
+                        TestDatabase::class.java,
+                        "testdb")
+                        .allowMainThreadQueries()
+                        .build()
+            }
+            return INSTANCE!!
+        }
+
+        fun destroyInstance() {
+            INSTANCE = null
+        }
+    }
+}

--- a/src/main/kotlin/com/email/db/dao/ResetDao.kt
+++ b/src/main/kotlin/com/email/db/dao/ResetDao.kt
@@ -1,0 +1,35 @@
+package com.email.db.dao
+
+import android.arch.persistence.room.Dao
+import android.arch.persistence.room.Query
+import android.arch.persistence.room.Transaction
+
+/**
+ * Created by gabriel on 3/17/18.
+ */
+
+@Dao
+interface ResetDao {
+    @Query("DELETE from raw_session")
+    fun deleteAllSessions()
+    @Query("DELETE from raw_identitykey")
+    fun deleteAllIdentityKeys()
+    @Query("DELETE from raw_signedprekey")
+    fun deleteAllSignedPreKey()
+    @Query("DELETE from raw_prekey")
+    fun deleteAllPreKey()
+    @Query("DELETE from account")
+    fun deleteAllAccounts()
+
+    /**
+     * Apparently transactions don't compile unless you pass at least one argument -__-
+     */
+    @Transaction
+    fun deleteAllData(lol: Int) {
+        deleteAllPreKey()
+        deleteAllSignedPreKey()
+        deleteAllSessions()
+        deleteAllIdentityKeys()
+        deleteAllAccounts()
+    }
+}

--- a/src/main/kotlin/com/email/db/dao/signal/RawSessionDao.kt
+++ b/src/main/kotlin/com/email/db/dao/signal/RawSessionDao.kt
@@ -1,9 +1,6 @@
 package com.email.db.dao.signal
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Delete
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.Query
+import android.arch.persistence.room.*
 import com.email.db.models.signal.CRSessionRecord
 
 /**
@@ -18,6 +15,16 @@ interface RawSessionDao {
 
     @Delete
     fun delete(crSessionRecord: CRSessionRecord)
+
+    /**
+     * Each time signal calls storeSession it should replace any existing value, which isn't
+     * exactly supported by SQL so let's delete first and then insert in a single transaction.
+     */
+    @Transaction
+    fun store(crSessionRecord: CRSessionRecord) {
+        delete(crSessionRecord)
+        insert(crSessionRecord)
+    }
 
     @Query("""SELECT * FROM raw_session
               WHERE recipientId = :recipientId AND deviceId = :deviceId LIMIT 1""")

--- a/src/main/kotlin/com/email/scenes/signup/IncompleteAccount.kt
+++ b/src/main/kotlin/com/email/scenes/signup/IncompleteAccount.kt
@@ -1,5 +1,8 @@
 package com.email.scenes.signup
 
+import com.email.db.models.Account
+import com.email.signal.SignalKeyGenerator
+
 /**
  * Created by sebas on 3/7/18.
  */
@@ -9,4 +12,14 @@ data class IncompleteAccount(
         val name: String,
         val password: String,
         val recoveryEmail: String?
-        )
+        ) {
+
+        fun complete(privateBundle: SignalKeyGenerator.PrivateBundle, jwt: String) =
+                Account(
+                        name = this.name,
+                        recipientId = this.username,
+                        jwt = jwt,
+                        registrationId = privateBundle.registrationId,
+                        identityB64 = privateBundle.identityKeyPair
+                )
+}

--- a/src/main/kotlin/com/email/scenes/signup/data/SignUpDataSource.kt
+++ b/src/main/kotlin/com/email/scenes/signup/data/SignUpDataSource.kt
@@ -25,7 +25,7 @@ class SignUpDataSource(override val runner: WorkRunner,
             is SignUpRequest.RegisterUser -> RegisterUserWorker(
                     db = signUpLocalDB,
                     apiClient = signUpAPIClient,
-                    account = params.account,
+                    incompleteAccount = params.account,
                     signalKeyGenerator = signalKeyGenerator,
                     keyValueStorage = keyValueStorage,
                     publishFn = { result ->

--- a/src/main/kotlin/com/email/signal/SignalStoreCriptext.kt
+++ b/src/main/kotlin/com/email/signal/SignalStoreCriptext.kt
@@ -118,9 +118,9 @@ class SignalStoreCriptext(rawSessionDao: RawSessionDao, rawIdentityKeyDao: RawId
 
         override fun storeSession(address: SignalProtocolAddress, record: SessionRecord) {
             val sessionRecord = Encoding.byteArrayToString(record.serialize())
-            val newRawSession = CRSessionRecord(recipientId = address.name, deviceId = address.deviceId,
+            val newRawSessionValue = CRSessionRecord(recipientId = address.name, deviceId = address.deviceId,
                     byteString = sessionRecord)
-            db.insert(newRawSession)
+            db.store(newRawSessionValue)
         }
 
     }


### PR DESCRIPTION
New classes TestDatabase and ResetDao to be used only in instrumentation tests.
New test LocalPersistentCommunicationTest creates one user in Room and
another in memory and makes them exchange messages.
Delete and insert session in SignalStoreCriptext's store session to
avoid errors when signal wants to update a session.
Add `complete()` method to IncompleteAccount that returns an Account
object.
InMemoryUser now subclasses new class TestUser. this makes it easier to
create instances of users in memory and in database