### PR TITLE
Modify LoadEmailThreadsWorker to load from start

### DIFF
--- a/src/main/kotlin/com/email/scenes/mailbox/data/LoadParams.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/data/LoadParams.kt
@@ -1,0 +1,9 @@
+package com.email.scenes.mailbox.data
+
+/**
+ * Created by gabriel on 5/2/18.
+ */
+sealed class LoadParams {
+    data class NewPage(val size: Int, val oldestEmailThread: EmailThread?): LoadParams()
+    data class Reset(val size: Int): LoadParams()
+}

--- a/src/main/kotlin/com/email/scenes/mailbox/data/MailboxDataSource.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/data/MailboxDataSource.kt
@@ -45,10 +45,8 @@ class MailboxDataSource(
 
             is MailboxRequest.LoadEmailThreads -> LoadEmailThreadsWorker(
                     db = mailboxLocalDB,
-                    activeAccount = activeAccount,
+                    loadParams = params.loadParams,
                     labelTextTypes = params.label,
-                    limit = params.limit,
-                    oldestEmailThread = params.oldestEmailThread,
                     publishFn = { result ->
                         flushResults(result)
                     })

--- a/src/main/kotlin/com/email/scenes/mailbox/data/MailboxRequest.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/data/MailboxRequest.kt
@@ -25,8 +25,7 @@ sealed class MailboxRequest{
 
     data class LoadEmailThreads(
             val label: MailFolders,
-            val limit: Int,
-            val oldestEmailThread: EmailThread?
+            val loadParams: LoadParams
             ): MailboxRequest()
 
     data class SendMail(val emailId: Long, val threadId: String?, val data: ComposerInputData): MailboxRequest()

--- a/src/main/kotlin/com/email/scenes/mailbox/data/MailboxResult.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/data/MailboxResult.kt
@@ -31,6 +31,7 @@ sealed class MailboxResult {
         abstract fun getDestinationMailbox(): MailFolders
         class Success(
                 val emailThreads: List<EmailThread>,
+                val isReset: Boolean,
                 val mailboxLabel: MailFolders): LoadEmailThreads() {
 
             override fun getDestinationMailbox(): MailFolders {

--- a/src/test/java/com/email/scenes/mailbox/MailboxSceneControllerTest.kt
+++ b/src/test/java/com/email/scenes/mailbox/MailboxSceneControllerTest.kt
@@ -100,21 +100,7 @@ class MailboxSceneControllerTest {
         ApiCall.baseUrl = server.url("v1/mock").toString()
     }
 
-    private fun createEmailThreads(size: Int): List<EmailThread> {
-        val dateMilis = System.currentTimeMillis()
-        return (1..size)
-                .map {
-                    val email = Email(id = it.toLong(), key = it.toString(), threadid = "thread$it", unread = true,
-                            secure = true, content = "this is message #$it", preview = "message #$it",
-                            subject = "message #$it", delivered = DeliveryTypes.DELIVERED,
-                            date = Date(dateMilis + it), isTrash = false, isDraft = false)
-                    val fullEmail = FullEmail(email, labels = listOf(Label.defaultItems.inbox),
-                            to = listOf(Contact(1, "gabriel@criptext.com", "gabriel")),
-                                    cc = emptyList(), bcc = emptyList(), files = emptyList(),
-                            from = Contact(2, "mayer@criptext.com", name = "Mayer"))
-                    EmailThread(fullEmail, listOf(Label.defaultItems.inbox), 0)
-                }
-    }
+
     @Test
     fun `should forward onStart and onStop to FeedController`() {
         controller.onStart(null)
@@ -133,7 +119,7 @@ class MailboxSceneControllerTest {
                     oldestEmailThread = null,
                     rejectedLabels = any(),
                     limit = 20)
-        } returns createEmailThreads(20)
+        } returns MailboxTestUtils.createEmailThreads(20)
 
         runner.assertPendingWork(listOf(GetMenuInformationWorker::class.java,
                 LoadEmailThreadsWorker::class.java))
@@ -151,7 +137,7 @@ class MailboxSceneControllerTest {
 
     @Test
     fun `onStart, should not try to load threads if is not empty`() {
-        model.threads.addAll(createEmailThreads(20))
+        model.threads.addAll(MailboxTestUtils.createEmailThreads(20))
 
         controller.onStart(null)
 

--- a/src/test/java/com/email/scenes/mailbox/MailboxTestUtils.kt
+++ b/src/test/java/com/email/scenes/mailbox/MailboxTestUtils.kt
@@ -1,0 +1,31 @@
+package com.email.scenes.mailbox
+
+import com.email.db.DeliveryTypes
+import com.email.db.models.Contact
+import com.email.db.models.Email
+import com.email.db.models.FullEmail
+import com.email.db.models.Label
+import com.email.scenes.mailbox.data.EmailThread
+import java.util.*
+
+/**
+ * Created by gabriel on 5/2/18.
+ */
+object MailboxTestUtils {
+
+    fun createEmailThreads(size: Int): List<EmailThread> {
+        val dateMilis = System.currentTimeMillis()
+        return (1..size)
+                .map {
+                    val email = Email(id = it.toLong(), key = it.toString(), threadid = "thread$it", unread = true,
+                            secure = true, content = "this is message #$it", preview = "message #$it",
+                            subject = "message #$it", delivered = DeliveryTypes.DELIVERED,
+                            date = Date(dateMilis + it), isTrash = false, isDraft = false)
+                    val fullEmail = FullEmail(email, labels = listOf(Label.defaultItems.inbox),
+                            to = listOf(Contact(1, "gabriel@criptext.com", "gabriel")),
+                                    cc = emptyList(), bcc = emptyList(), files = emptyList(),
+                            from = Contact(2, "mayer@criptext.com", name = "Mayer"))
+                    EmailThread(fullEmail, listOf(Label.defaultItems.inbox), 0)
+                }
+    }
+}

--- a/src/test/java/com/email/scenes/mailbox/MailboxWebSocketTest.kt
+++ b/src/test/java/com/email/scenes/mailbox/MailboxWebSocketTest.kt
@@ -1,0 +1,126 @@
+package com.email.scenes.mailbox
+
+import com.email.IHostActivity
+import com.email.api.ApiCall
+import com.email.db.MailFolders
+import com.email.db.MailboxLocalDB
+import com.email.db.dao.EmailInsertionDao
+import com.email.db.dao.signal.RawSessionDao
+import com.email.db.models.ActiveAccount
+import com.email.mocks.MockedWorkRunner
+import com.email.scenes.mailbox.data.MailboxAPIClient
+import com.email.scenes.mailbox.data.MailboxDataSource
+import com.email.scenes.mailbox.feed.FeedController
+import com.email.signal.SignalClient
+import com.email.websocket.WebSocketEventListener
+import com.email.websocket.WebSocketEventPublisher
+import io.mockk.*
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.`should be`
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Created by gabriel on 5/2/18.
+ */
+class MailboxWebSocketTest {
+    private lateinit var model: MailboxSceneModel
+    private lateinit var scene: MailboxScene
+    private lateinit var signal: SignalClient
+    private lateinit var db: MailboxLocalDB
+    private lateinit var rawSessionDao: RawSessionDao
+    private lateinit var emailInsertionDao: EmailInsertionDao
+    private lateinit var api: MailboxAPIClient
+    private lateinit var runner: MockedWorkRunner
+    private lateinit var dataSource: MailboxDataSource
+    private lateinit var controller: MailboxSceneController
+    private lateinit var host: IHostActivity
+    private lateinit var webSocketEvents: WebSocketEventPublisher
+    private lateinit var webSocketListenerSlot: CapturingSlot<WebSocketEventListener>
+    private lateinit var feedController : FeedController
+    private lateinit var server : MockWebServer
+
+    @Before
+    fun setUp() {
+        model = MailboxSceneModel()
+        scene = mockk(relaxed = true)
+
+        runner = MockedWorkRunner()
+        db = mockk(relaxed = true)
+        rawSessionDao = mockk()
+
+        emailInsertionDao = mockk(relaxed = true)
+        val runnableSlot = CapturingSlot<Runnable>() // run transactions as they are invoked
+        every { emailInsertionDao.runTransaction(capture(runnableSlot)) } answers {
+            runnableSlot.captured.run()
+        }
+
+        api = MailboxAPIClient("__JWT_TOKEN")
+        signal = mockk()
+
+        host = mockk()
+
+        dataSource = MailboxDataSource(
+                runner = runner,
+                signalClient = signal,
+                mailboxLocalDB = db,
+                activeAccount = ActiveAccount("gabriel", "__JWT_TOKEN__"),
+                rawSessionDao = rawSessionDao,
+                emailInsertionDao = emailInsertionDao
+        )
+
+        feedController = mockk(relaxed = true)
+
+        // capture web socket event listener
+        webSocketListenerSlot = CapturingSlot()
+        webSocketEvents = mockk(relaxed = true)
+        every { webSocketEvents::listener.set(capture(webSocketListenerSlot)) } just Runs
+
+        controller = MailboxSceneController(
+                model =  model,
+                scene = scene,
+                dataSource = dataSource,
+                host =  host,
+                feedController = feedController,
+                websocketEvents = webSocketEvents
+        )
+
+        server = MockWebServer()
+        ApiCall.baseUrl = server.url("v1/mock").toString()
+    }
+
+    @Test
+    fun `should reset the mailbox when an email for inbox arrives`() {
+        controller.onStart(null)
+
+        // skip all initialization
+        runner.discardPendingWork()
+
+        // mock database result
+        every {
+            db.getEmailsFromMailboxLabel(MailFolders.INBOX, null, 20, any())
+        } returns MailboxTestUtils.createEmailThreads(20)
+
+        // set 2 pages of threads
+        model.threads.addAll(MailboxTestUtils.createEmailThreads(40))
+
+        // create new email to "send" through web socket
+        val newEmail = MailboxTestUtils.createEmailThreads(1).first().latestEmail.email
+        newEmail.subject = "New real time email"
+        newEmail.threadid = "__THREAD_ID__"
+
+
+        // trigger socket event
+        webSocketListenerSlot.captured.onNewEmail(newEmail)
+
+
+        // assert that model has not updated until async task finishes
+        model.threads.size `should be` 40
+
+        // async work done
+        runner._work()
+
+        // should have removed the previous 40 and added the 20 loaded from db
+        model.threads.size `should be` 20
+    }
+}


### PR DESCRIPTION
Add new parameter loadParams to `LoadEmailThreadsWorker` so that the
worker can optionally load threads from start instead of trying to load
the next page. Use this option when a new email is received via web
socket.