### PR TITLE
sending own email to peer devices resolves #84, receiving own email in inbox

### DIFF
--- a/src/main/kotlin/com/email/db/dao/EmailInsertionDao.kt
+++ b/src/main/kotlin/com/email/db/dao/EmailInsertionDao.kt
@@ -36,6 +36,10 @@ interface EmailInsertionDao {
     @Insert
     fun insertEmailLabelRelations(emailLabelRelations: List<EmailLabel>)
 
+    @Query("""DELETE FROM email_label
+        WHERE labelId= :labelId AND emailId=:emailId""")
+    fun deleteByEmailLabelIds(labelId: Long, emailId: Long)
+
     @Insert
     fun insertEmailContactRelations(emailContactRelations: List<EmailContact>)
 

--- a/src/main/kotlin/com/email/scenes/mailbox/data/ExistingEmailUpdateSetup.kt
+++ b/src/main/kotlin/com/email/scenes/mailbox/data/ExistingEmailUpdateSetup.kt
@@ -1,0 +1,34 @@
+package com.email.scenes.mailbox.data
+
+import com.email.api.models.EmailMetadata
+import com.email.db.AppDatabase
+import com.email.db.dao.EmailInsertionDao
+import com.email.db.models.ActiveAccount
+import com.email.db.models.Email
+import com.email.db.models.EmailLabel
+import com.email.db.models.Label
+
+object ExistingEmailUpdateSetup {
+
+    val defaultItems = Label.DefaultItems()
+
+    fun updateExistingEmailTransaction(metadata: EmailMetadata, dao: EmailInsertionDao,
+                                       activeAccount: ActiveAccount): Email {
+        val existingEmail = dao.findEmailByMessageId(metadata.messageId)!!
+        if(metadata.senderRecipientId == activeAccount.recipientId){
+            dao.deleteByEmailLabelIds(labelId = defaultItems.sent.id, emailId = existingEmail.id)
+            val emailLabel = EmailLabel(emailId = existingEmail.id, labelId = defaultItems.sent.id)
+            dao.insertEmailLabelRelations(listOf(emailLabel))
+        }
+        if(metadata.bcc.contains(activeAccount.userEmail)
+                || metadata.cc.contains(activeAccount.userEmail)
+                || metadata.to.contains(activeAccount.userEmail)){
+            dao.deleteByEmailLabelIds(labelId = defaultItems.inbox.id, emailId = existingEmail.id)
+            dao.deleteByEmailLabelIds(labelId = defaultItems.inbox.id, emailId = existingEmail.id)
+            val emailLabel = EmailLabel(emailId = existingEmail.id, labelId = defaultItems.inbox.id)
+            dao.insertEmailLabelRelations(listOf(emailLabel))
+        }
+        return existingEmail
+    }
+
+}

--- a/src/main/kotlin/com/email/websocket/WebSocketSingleton.kt
+++ b/src/main/kotlin/com/email/websocket/WebSocketSingleton.kt
@@ -23,7 +23,8 @@ object WebSocketSingleton {
         val dataSource = EventDataSource(runner = AsyncTaskWorkRunner(),
                 emailInsertionDao = appDB.emailInsertionDao(), emailDao = appDB.emailDao(),
                 emailInsertionAPIClient = EmailInsertionAPIClient(HttpClient.Default(), activeAccount.jwt),
-                signalClient = SignalClient.Default(SignalStoreCriptext(appDB)))
+                signalClient = SignalClient.Default(SignalStoreCriptext(appDB)),
+                activeAccount = activeAccount)
 
         INSTANCE = WebSocketController(
                 NVWebSocketClient(), activeAccount, dataSource)

--- a/src/main/kotlin/com/email/websocket/data/EventDataSource.kt
+++ b/src/main/kotlin/com/email/websocket/data/EventDataSource.kt
@@ -6,6 +6,7 @@ import com.email.bgworker.BackgroundWorkManager
 import com.email.bgworker.WorkRunner
 import com.email.db.dao.EmailDao
 import com.email.db.dao.EmailInsertionDao
+import com.email.db.models.ActiveAccount
 import com.email.signal.SignalClient
 
 /**
@@ -16,13 +17,15 @@ class EventDataSource(override val runner: WorkRunner,
                       private val emailDao: EmailDao,
                       private val emailInsertionDao: EmailInsertionDao,
                       private val emailInsertionAPIClient: EmailInsertionAPIClient,
-                      private val signalClient: SignalClient): BackgroundWorkManager<EventRequest, EventResult>() {
+                      private val signalClient: SignalClient,
+                      private val activeAccount: ActiveAccount): BackgroundWorkManager<EventRequest, EventResult>() {
 
     override fun createWorkerFromParams(params: EventRequest, flushResults: (EventResult) -> Unit): BackgroundWorker<*> {
         return when (params) {
             is EventRequest.InsertNewEmail -> InsertNewEmailWorker(
                     emailInsertionDao = emailInsertionDao, signalClient = signalClient,
                     emailInsertionApi = emailInsertionAPIClient, metadata = params.emailMetadata,
+                    activeAccount = activeAccount,
                     publishFn = flushResults)
             is EventRequest.UpdateDeliveryStatus -> UpdateDeliveryStatusWorker(
                     dao = emailDao, trackingUpdate = params.trackingUpdate, publishFn = flushResults

--- a/src/test/java/com/email/websocket/WebSocketTests.kt
+++ b/src/test/java/com/email/websocket/WebSocketTests.kt
@@ -54,14 +54,14 @@ class WebSocketTests {
 
         runner = MockedWorkRunner()
 
+        val account = ActiveAccount(name = "Gabriel", recipientId = "tester", deviceId = 1,
+                jwt = "__JWT_TOKEN__", signature = "")
+
         dataSource = EventDataSource(runner = runner, emailInsertionDao = dao, emailDao = emailDao,
-                emailInsertionAPIClient = api, signalClient = signal)
+                emailInsertionAPIClient = api, signalClient = signal, activeAccount = account)
 
         webSocket = mockk()
         every { webSocket.connect(any(), capture(onMessageReceivedSlot))} just Runs
-
-        val account = ActiveAccount(name = "Gabriel", recipientId = "tester", deviceId = 1,
-                jwt = "__JWT_TOKEN__", signature = "")
 
         controller = WebSocketController(wsClient = webSocket, activeAccount = account,
                 eventDataSource = dataSource)


### PR DESCRIPTION
- When sending email, peer devices are added within post email request
- Receiving an existing email checks whether it should be in inbox or sent
- Receiving new email also checks the above condition