### PR TITLE
Changed backticks symbols, since the tests were crashing on windows.

### DIFF
--- a/src/test/java/com/email/scenes/mailbox/MailboxControllerDataSourceEventsTest.kt
+++ b/src/test/java/com/email/scenes/mailbox/MailboxControllerDataSourceEventsTest.kt
@@ -135,7 +135,7 @@ class MailboxControllerDataSourceEventsTest: MailboxControllerTest() {
     }
 
     @Test
-    fun `after updating mailbox, if isManual is true, should try to clear "refreshing" animation`() {
+    fun `after updating mailbox, if isManual is true, should try to clear ~refreshing~ animation`() {
         controller.onStart(null)
         clearMocks(virtualListView)
         clearMocks(scene)

--- a/src/test/java/com/email/scenes/mailbox/data/LoadEmailThreadsWorkerTest.kt
+++ b/src/test/java/com/email/scenes/mailbox/data/LoadEmailThreadsWorkerTest.kt
@@ -65,7 +65,7 @@ class LoadEmailThreadsWorkerTest: MailboxWorkerTest() {
     }
 
     @Test
-    fun `should load inbox threads from beginning with the "Reset" parameter`() {
+    fun `should load inbox threads from beginning with the ~Reset~ parameter`() {
         val selectedFolder = Label.defaultItems.inbox.text
         val expectedThreads = MailboxTestUtils.createEmailThreads(20)
 


### PR DESCRIPTION
Some tests were crashing on compilation on Windows, since the symbol " inside backticks is not supported on that platform, this is a known issue in Kotlin. Changed the symbols to ~

Kotlin Issue: https://youtrack.jetbrains.com/issue/KT-17438