### PR TITLE
Various needed fixes and additions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ android {
         multiDexEnabled true
     }
 
+    applicationVariants.all { variant ->
+        variant.resValue "string", "versionName", variant.versionName
+    }
+
     testOptions {
         unitTests {
             includeAndroidResources = true
@@ -179,6 +183,8 @@ dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true;
     }
+
+    implementation 'com.github.danieltigse:TimeDurationPicker:0.3'
 
     // file picker
 

--- a/src/main/kotlin/com/criptext/mail/api/HttpClient.kt
+++ b/src/main/kotlin/com/criptext/mail/api/HttpClient.kt
@@ -1,6 +1,5 @@
 package com.criptext.mail.api
 
-import android.webkit.URLUtil
 import com.criptext.mail.api.models.MultipartFormItem
 import com.criptext.mail.utils.file.FileUtils
 import okhttp3.*
@@ -17,7 +16,7 @@ interface HttpClient {
     fun post(path: String, authToken: String?, body: JSONObject): String
     fun put(path: String, authToken: String?, body: JSONObject): String
     fun get(path: String, authToken: String?): String
-    fun delete(path: String, authToken: String?, param: Pair<String, String>): String
+    fun delete(path: String, authToken: String?): String
     fun getFile(path: String, authToken: String?): ByteArray
 
     enum class AuthScheme { basic, jwt }
@@ -45,9 +44,8 @@ interface HttpClient {
                 AuthScheme.jwt -> this.addHeader("Authorization", "Bearer $authToken")
             }
 
-        private fun deleteWithParams(url: String, authToken: String?, params: Pair<String, String>): Request {
+        private fun deleteWithoutParams(url: String, authToken: String?): Request {
             val newUrl = HttpUrl.parse(url)!!.newBuilder()
-            newUrl.addQueryParameter(params.first, params.second)
             val url = newUrl.build()
             return Request.Builder()
                     .addAuthorizationHeader(authToken)
@@ -165,8 +163,8 @@ interface HttpClient {
             return ApiCall.executeRequest(client, request)
         }
 
-        override fun delete(path: String, authToken: String?, param: Pair<String, String>): String {
-            val request = deleteWithParams(url = baseUrl + path, authToken = authToken, params = param)
+        override fun delete(path: String, authToken: String?): String {
+            val request = deleteWithoutParams(url = baseUrl + path, authToken = authToken)
             return ApiCall.executeRequest(client, request)
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerActivity.kt
@@ -40,7 +40,7 @@ class ComposerActivity : BaseActivity() {
                 composerLocalDB = db,
                 activeAccount = activeAccount,
                 emailInsertionDao = appDB.emailInsertionDao(),
-                runner = AsyncTaskWorkRunner(), authToken = Hosts.fileServiceAuthToken)
+                runner = AsyncTaskWorkRunner())
         return ComposerController(
                 model = model,
                 scene = scene,

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerController.kt
@@ -1,5 +1,6 @@
 package com.criptext.mail.scenes.composer
 
+
 import android.Manifest
 import android.content.DialogInterface
 import android.content.pm.PackageManager
@@ -10,6 +11,7 @@ import com.criptext.mail.R
 import com.criptext.mail.aes.AESUtil
 import com.criptext.mail.bgworker.BackgroundWorkManager
 import com.criptext.mail.db.models.ActiveAccount
+import com.criptext.mail.db.models.Contact
 import com.criptext.mail.scenes.ActivityMessage
 import com.criptext.mail.scenes.SceneController
 import com.criptext.mail.scenes.composer.data.*
@@ -226,11 +228,11 @@ class ComposerController(private val model: ComposerModel,
 
     private fun updateModelWithInputData(data: ComposerInputData) {
         model.to.clear()
-        model.to.addAll(data.to)
+        model.to.addAll(data.to.map { Contact(it.id, it.email.decapitalize(), it.name) })
         model.cc.clear()
-        model.cc.addAll(data.cc)
+        model.cc.addAll(data.cc.map { Contact(it.id, it.email.decapitalize(), it.name) })
         model.bcc.clear()
-        model.bcc.addAll(data.bcc)
+        model.bcc.addAll(data.bcc.map { Contact(it.id, it.email.decapitalize(), it.name) })
         model.body = data.body
         model.subject = data.subject
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/data/ComposerDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/data/ComposerDataSource.kt
@@ -17,7 +17,6 @@ class ComposerDataSource(
         private val composerLocalDB: ComposerLocalDB,
         private val activeAccount: ActiveAccount,
         private val emailInsertionDao: EmailInsertionDao,
-        private val authToken: String,
         override val runner: WorkRunner)
     : BackgroundWorkManager<ComposerRequest, ComposerResult>() {
 
@@ -41,7 +40,7 @@ class ComposerDataSource(
                     db = composerLocalDB,
                     publishFn = { res -> flushResults(res) })
             is ComposerRequest.UploadAttachment -> UploadAttachmentWorker(filepath = params.filepath,
-                    httpClient = httpClient, fileServiceAuthToken = authToken,
+                    httpClient = httpClient, activeAccount = activeAccount,
                     publishFn = { res -> flushResults(res)}, fileKey = params.fileKey)
             is ComposerRequest.LoadInitialData -> LoadInitialDataWorker(db = composerLocalDB,
                     emailId = params.emailId,

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/data/PostEmailBody.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/data/PostEmailBody.kt
@@ -2,6 +2,7 @@ package com.criptext.mail.scenes.composer.data
 
 import com.criptext.mail.api.JSONData
 import com.criptext.mail.signal.SignalEncryptedData
+import com.criptext.mail.utils.Encoding
 import com.criptext.mail.utils.file.FileUtils
 import org.json.JSONArray
 import org.json.JSONObject
@@ -68,9 +69,15 @@ class PostEmailBody(val threadId: String?, val subject: String,
             json.put("cc", JSONArray(cc))
             json.put("bcc", JSONArray(bcc))
             json.put("body", body)
-            json.put("session", session)
-            json.put("salt", salt)
-            json.put("iv", iv)
+            if(session != null && iv != null && salt != null) {
+                val saltBytes = Encoding.stringToByteArray(salt)
+                val ivBytes = Encoding.stringToByteArray(iv)
+                val sessionBytes =  Encoding.stringToByteArray(session)
+                val newEncodedSession = Encoding.byteArrayToString(
+                        saltBytes + ivBytes + sessionBytes)
+                json.put("session", newEncodedSession)
+            }else
+                json.put("session", null)
             return json
         }
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/data/UploadAttachmentWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/data/UploadAttachmentWorker.kt
@@ -8,6 +8,7 @@ import com.criptext.mail.api.HttpErrorHandlingHelper
 import com.criptext.mail.api.ServerErrorException
 import com.criptext.mail.bgworker.BackgroundWorker
 import com.criptext.mail.bgworker.ProgressReporter
+import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.utils.UIMessage
 import com.criptext.mail.utils.file.ChunkFileReader
 import com.github.kittinunf.result.Result
@@ -19,13 +20,13 @@ import java.io.File
 
 class UploadAttachmentWorker(private val filepath: String,
                              httpClient: HttpClient,
-                             fileServiceAuthToken: String,
+                             activeAccount: ActiveAccount,
                              val fileKey: String?,
                              override val publishFn: (ComposerResult.UploadFile) -> Unit)
     : BackgroundWorker<ComposerResult.UploadFile> {
     override val canBeParallelized = false
 
-    val fileServiceAPIClient = FileServiceAPIClient(httpClient, fileServiceAuthToken)
+    val fileServiceAPIClient = FileServiceAPIClient(httpClient, activeAccount.jwt)
 
     override fun catchException(ex: Exception): ComposerResult.UploadFile {
          return ComposerResult.UploadFile.Failure(filepath, createErrorMessage(ex))

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailActivity.kt
@@ -56,7 +56,6 @@ class  EmailDetailActivity: BaseActivity() {
                         activeAccount = activeAccount,
                         filesHttpClient= filesHttpClient,
                         emailDetailLocalDB = db,
-                        fileServiceAuthToken = Hosts.fileServiceAuthToken,
                         downloadDir = downloadDir
                 )
         )

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/data/EmailDetailDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/data/EmailDetailDataSource.kt
@@ -22,7 +22,6 @@ class EmailDetailDataSource(override val runner: WorkRunner,
                             private val activeAccount: ActiveAccount,
                             private val emailDetailLocalDB: EmailDetailLocalDB,
                             private val filesHttpClient: HttpClient,
-                            private val fileServiceAuthToken: String,
                             private val downloadDir: String)
     : BackgroundWorkManager<EmailDetailRequest, EmailDetailResult>()
 {
@@ -115,7 +114,7 @@ class EmailDetailDataSource(override val runner: WorkRunner,
                     fileKey = params.fileKey,
                     downloadPath = downloadDir,
                     httpClient = filesHttpClient,
-                    fileServiceAuthToken = fileServiceAuthToken,
+                    activeAccount = activeAccount,
                     publishFn = { result ->
                         flushResults(result)
                     })

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/holders/FullEmailHolder.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/holders/FullEmailHolder.kt
@@ -261,6 +261,9 @@ class FullEmailHolder(view: View) : ParentEmailHolder(view) {
         readView.visibility = View.VISIBLE
 
         when(deliveryType){
+            DeliveryTypes.UNSEND -> {
+                readView.visibility = View.GONE
+            }
             DeliveryTypes.SENDING -> {
                 setIconAndColor(R.drawable.clock, R.color.sent)
             }
@@ -272,9 +275,6 @@ class FullEmailHolder(view: View) : ParentEmailHolder(view) {
             }
             DeliveryTypes.SENT -> {
                 setIconAndColor(R.drawable.mail_sent, R.color.sent)
-            }
-            DeliveryTypes.UNSEND -> {
-                readView.visibility = View.GONE
             }
             DeliveryTypes.NONE -> {
                 readView.visibility = View.GONE

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/holders/PartialEmailHolder.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/holders/PartialEmailHolder.kt
@@ -80,6 +80,9 @@ open class PartialEmailHolder(view: View) : ParentEmailHolder(view) {
         check.visibility = View.VISIBLE
 
         when(deliveryType){
+            DeliveryTypes.UNSEND -> {
+                check.visibility = View.GONE
+            }
             DeliveryTypes.SENDING -> {
                 setIconAndColor(R.drawable.clock, R.color.sent)
             }

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/workers/DownloadAttachmentWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/workers/DownloadAttachmentWorker.kt
@@ -9,6 +9,7 @@ import com.criptext.mail.api.HttpErrorHandlingHelper
 import com.criptext.mail.api.ServerErrorException
 import com.criptext.mail.bgworker.BackgroundWorker
 import com.criptext.mail.bgworker.ProgressReporter
+import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.scenes.composer.data.FileServiceAPIClient
 import com.criptext.mail.scenes.emaildetail.data.EmailDetailResult
 import com.criptext.mail.utils.UIMessage
@@ -25,15 +26,15 @@ class DownloadAttachmentWorker(private val fileToken: String,
                                private val emailId: Long,
                                private val fileKey: String?,
                                private val downloadPath: String,
-                             httpClient: HttpClient,
-                             fileServiceAuthToken: String,
+                               httpClient: HttpClient,
+                               activeAccount: ActiveAccount,
                              override val publishFn: (EmailDetailResult.DownloadFile) -> Unit)
     : BackgroundWorker<EmailDetailResult.DownloadFile> {
 
     override val canBeParallelized = false
     var filepath = ""
 
-    private val fileServiceAPIClient = FileServiceAPIClient(httpClient, fileServiceAuthToken)
+    private val fileServiceAPIClient = FileServiceAPIClient(httpClient, activeAccount.jwt)
 
     override fun catchException(ex: Exception): EmailDetailResult.DownloadFile {
         return EmailDetailResult.DownloadFile.Failure(fileToken, createErrorMessage(ex))

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxSceneController.kt
@@ -507,6 +507,7 @@ class MailboxSceneController(private val scene: MailboxScene,
                     reloadMailboxThreads()
                     dataSource.submitRequest(MailboxRequest.GetMenuInformation())
                 } else -> {
+                    threadListController.reRenderAll()
                     scene.showMessage(UIMessage(R.string.error_updating_labels))
                 }
             }
@@ -520,6 +521,7 @@ class MailboxSceneController(private val scene: MailboxScene,
                     feedController.reloadFeeds()
                     dataSource.submitRequest(MailboxRequest.GetMenuInformation())
                 } else -> {
+                    threadListController.reRenderAll()
                     scene.showMessage(UIMessage(R.string.error_moving_threads))
                 }
             }
@@ -570,6 +572,7 @@ class MailboxSceneController(private val scene: MailboxScene,
                     dataSource.submitRequest(MailboxRequest.GetMenuInformation())
                 }
                 is MailboxResult.UpdateUnreadStatus.Failure -> {
+                    threadListController.reRenderAll()
                     scene.showMessage(UIMessage(R.string.error_updating_status))
                 }
             }

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/data/EmailInsertionSetup.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/data/EmailInsertionSetup.kt
@@ -63,9 +63,9 @@ object EmailInsertionSetup {
 
         val toAddresses = addressesCSV.split(",").map {
             if(it.contains("<") && it.contains(">"))
-                it.substring(it.indexOf("<"), it.indexOf(">"))
+                it.substring(it.indexOf("<"), it.indexOf(">")).removeSurrounding("\"")
             else
-                it
+                it.removeSurrounding("\"")
         }
         val toAddressesNotDuplicated = toAddresses.toSet().toList()
         val existingContacts = dao.findContactsByEmail(toAddressesNotDuplicated)

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/data/MailboxDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/data/MailboxDataSource.kt
@@ -87,6 +87,8 @@ class MailboxDataSource(
                     selectedLabels = params.selectedLabels,
                     currentLabel = params.currentLabel,
                     shouldRemoveCurrentLabel = params.shouldRemoveCurrentLabel,
+                    httpClient = httpClient,
+                    activeAccount = activeAccount,
                     publishFn = { result ->
                         flushResults(result)
                     })

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/data/UpdateEmailThreadsLabelsWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/data/UpdateEmailThreadsLabelsWorker.kt
@@ -1,13 +1,18 @@
 package com.criptext.mail.scenes.mailbox.data
 
 import com.criptext.mail.R
+import com.criptext.mail.api.HttpClient
+import com.criptext.mail.api.HttpErrorHandlingHelper
 import com.criptext.mail.bgworker.BackgroundWorker
 import com.criptext.mail.bgworker.ProgressReporter
 import com.criptext.mail.db.MailboxLocalDB
+import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.db.models.EmailLabel
 import com.criptext.mail.db.models.Label
 import com.criptext.mail.scenes.label_chooser.SelectedLabels
 import com.criptext.mail.utils.UIMessage
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.mapError
 
 /**
  * Created by sebas on 04/05/18.
@@ -19,12 +24,16 @@ class UpdateEmailThreadsLabelsWorker(
         private val selectedThreadIds: List<String>,
         private val currentLabel: Label,
         private val shouldRemoveCurrentLabel: Boolean,
+        httpClient: HttpClient,
+        activeAccount: ActiveAccount,
         override val publishFn: (
                 MailboxResult.UpdateEmailThreadsLabelsRelations) -> Unit)
     : BackgroundWorker<MailboxResult.UpdateEmailThreadsLabelsRelations> {
 
     private val defaultItems = Label.DefaultItems()
     override val canBeParallelized = false
+
+    private val apiClient = MailboxAPIClient(httpClient, activeAccount.jwt)
 
     override fun catchException(ex: Exception): MailboxResult.UpdateEmailThreadsLabelsRelations {
 
@@ -57,18 +66,33 @@ class UpdateEmailThreadsLabelsWorker(
     override fun work(reporter: ProgressReporter<MailboxResult.UpdateEmailThreadsLabelsRelations>)
             : MailboxResult.UpdateEmailThreadsLabelsRelations? {
 
+        val removedLabels = if(currentLabel == defaultItems.starred
+                || currentLabel == defaultItems.sent) listOf(Label.defaultItems.inbox.text)
+        else
+            listOf(currentLabel.text)
+
         val rejectedLabels = defaultItems.rejectedLabelsByMailbox(currentLabel).map { it.id }
         val emailIds = selectedThreadIds.flatMap { threadId ->
             db.getEmailsByThreadId(threadId, rejectedLabels).map { it.id }
-
         }
 
-        if(shouldRemoveCurrentLabel)
-            removeCurrentLabelFromEmails(emailIds)
-        else
-            updateLabelEmailRelations(emailIds)
+        val result = Result.of {
+            apiClient.postThreadLabelChangedEvent(selectedThreadIds, removedLabels,
+                    selectedLabels.toList().map { it.text })}
+                .mapError(HttpErrorHandlingHelper.httpExceptionsToNetworkExceptions)
 
-        return MailboxResult.UpdateEmailThreadsLabelsRelations.Success()
+        return when(result){
+            is Result.Success -> {
+                if(shouldRemoveCurrentLabel)
+                    removeCurrentLabelFromEmails(emailIds)
+                else
+                    updateLabelEmailRelations(emailIds)
+                MailboxResult.UpdateEmailThreadsLabelsRelations.Success()
+            }
+            is Result.Failure -> {
+                catchException(result.error)
+            }
+        }
     }
 
     override fun cancel() {

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/holders/EmailHolder.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/holders/EmailHolder.kt
@@ -112,6 +112,9 @@ class EmailHolder(val view: View) : RecyclerView.ViewHolder(view), View.OnClickL
         check.visibility = View.VISIBLE
 
         when(deliveryType){
+            DeliveryTypes.UNSEND -> {
+                check.visibility = View.GONE
+            }
             DeliveryTypes.SENDING -> {
                 setIconAndColor(R.drawable.clock, R.color.sent)
             }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
@@ -189,6 +189,7 @@ class SettingsController(
                 host.goToScene(SignInParams(), false)
             }
             is SettingsResult.Logout.Failure -> {
+                scene.dismissLoginOutDialog()
                 scene.showMessage(UIMessage(R.string.error_login_out))
             }
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsLoginOutDialog.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsLoginOutDialog.kt
@@ -47,4 +47,8 @@ class SettingsLoginOutDialog(val context: Context) {
 
         return newLogoutDialog
     }
+
+    fun dismiss() {
+        dialog?.dismiss()
+    }
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsScene.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsScene.kt
@@ -24,6 +24,7 @@ interface SettingsScene{
     fun showProfileNameDialog(fullName: String)
     fun showLogoutDialog()
     fun showLoginOutDialog()
+    fun dismissLoginOutDialog()
     fun showCreateLabelDialog(keyboardManager: KeyboardManager)
     fun getLabelListView(): VirtualListView
 
@@ -90,6 +91,10 @@ interface SettingsScene{
 
         override fun showLoginOutDialog() {
             settingLoginOutDialog.showLoginOutDialog(settingsUIObserver)
+        }
+
+        override fun dismissLoginOutDialog() {
+            settingLoginOutDialog.dismiss()
         }
 
         override fun getLabelListView(): VirtualListView {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsAPIClient.kt
@@ -38,7 +38,7 @@ class SettingsAPIClient(private val httpClient: HttpClient, private val token: S
     }
 
     fun deleteDevice(deviceId: Int): String{
-        return httpClient.delete(path = "/devices", authToken = token, param = Pair("deviceId", deviceId.toString()))
+        return httpClient.delete(path = "/devices/$deviceId", authToken = token)
     }
 
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
@@ -1,9 +1,13 @@
 package com.criptext.mail.scenes.settings.views
 
+import android.content.res.Resources
 import android.view.View
+import android.widget.TextView
+import com.criptext.mail.BuildConfig
 import com.criptext.mail.R
 import com.criptext.mail.scenes.settings.SettingsUIObserver
 import com.criptext.mail.utils.ui.TabView
+import kotlinx.android.synthetic.main.deckard.view.*
 
 class GeneralSettingsView(view: View, title: String): TabView(view, title) {
 
@@ -13,8 +17,11 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
     private lateinit var settingsTermsOfService: View
     private lateinit var settingsOpenSourceLibraries: View
     private lateinit var settingsLogout: View
+    private lateinit var versionText: TextView
 
     private var settingsUIObserver: SettingsUIObserver? = null
+
+    private val versionString ="Criptext System Version ${BuildConfig.VERSION_NAME}"
 
     override fun onCreateView(){
 
@@ -24,6 +31,8 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
         settingsTermsOfService = view.findViewById(R.id.settings_terms_of_service)
         settingsOpenSourceLibraries = view.findViewById(R.id.settings_open_source_libraries)
         settingsLogout = view.findViewById(R.id.settings_logout)
+        versionText = view.findViewById(R.id.version_text) as TextView
+        versionText.text = BuildConfig.VERSION_NAME
 
         setButtonListeners()
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
@@ -12,6 +12,7 @@ import com.criptext.mail.scenes.signin.data.SignInResult
 import com.criptext.mail.scenes.signin.holders.SignInLayoutState
 import com.criptext.mail.utils.KeyboardManager
 import com.criptext.mail.utils.UIMessage
+import com.criptext.mail.utils.sha256
 import com.criptext.mail.validation.AccountDataValidator
 import com.criptext.mail.validation.FormData
 import com.criptext.mail.validation.ProgressButtonState
@@ -112,9 +113,12 @@ class SignInSceneController(
             model.state = currentState.copy(buttonState = newButtonState)
             scene.setSubmitButtonState(newButtonState)
 
+            val hashedPassword = (currentState.username.substring(0 .. 3)
+                    + currentState.password).sha256()
+
             val req = SignInRequest.AuthenticateUser(
                     username = currentState.username,
-                    password = currentState.password
+                    password = hashedPassword
             )
             dataSource.submitRequest(req)
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/signup/SignUpSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signup/SignUpSceneController.kt
@@ -15,6 +15,7 @@ import com.criptext.mail.scenes.params.SignInParams
 import com.criptext.mail.scenes.signup.data.SignUpRequest
 import com.criptext.mail.scenes.signup.data.SignUpResult
 import com.criptext.mail.utils.UIMessage
+import com.criptext.mail.utils.sha256
 import com.criptext.mail.validation.AccountDataValidator
 import com.criptext.mail.validation.FormData
 import com.criptext.mail.validation.FormInputState
@@ -257,10 +258,13 @@ class SignUpSceneController(
     private fun submitCreateUser() {
         scene.showKeyGenerationHolder()
 
+        val hashedPassword = (model.username.value.substring(0 .. 3)
+                + model.password).sha256()
+
         val newAccount = IncompleteAccount(
                 username = model.username.value,
                 name = model.fullName.value,
-                password = model.password,
+                password = hashedPassword,
                 deviceId = 1,
                 recoveryEmail = if (isSetRecoveryEmail) model.recoveryEmail.value else null
         )

--- a/src/main/kotlin/com/criptext/mail/utils/HTMLUtils.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/HTMLUtils.kt
@@ -1,6 +1,8 @@
 package com.criptext.mail.utils
 
+import com.criptext.mail.scenes.composer.data.ComposerAttachment
 import com.criptext.mail.utils.WebViewUtils.Companion.collapseScript
+import com.criptext.mail.utils.file.FileUtils
 import org.jsoup.Jsoup
 
 class HTMLUtils {
@@ -22,6 +24,28 @@ class HTMLUtils {
             return if (bodyWithoutHTML.length > 100 )
                 bodyWithoutHTML.substring(0,100)
             else bodyWithoutHTML
+        }
+
+        fun createAttchmentForUnencryptedEmailToNonCriptextUsers(attachment: ComposerAttachment,
+                                                                 encodedParams: String,
+                                                                 mimeTypeSource: String): String{
+            return """
+                <div style="margin-top: 6px; float: left;">
+                  <a style="cursor: pointer; text-decoration: none;" href="https://services.criptext.com/downloader/$encodedParams?e=1">
+                    <div style="align-items: center; border: 1px solid #e7e5e5; border-radius: 6px; display: flex; height: 20px; margin-right: 20px; padding: 10px; position: relative; width: 236px;">
+                      <div style="position: relative;">
+                        <div style="align-items: center; border-radius: 4px; display: flex; height: 22px; width: 22px;">
+                          <img src="https://cdn.criptext.com/External-Email/imgs/$mimeTypeSource.png" style="height: 100%; width: 100%;"/>
+                        </div>
+                      </div>
+                      <div style="padding-top: 1px; display: flex; flex-grow: 1; height: 100%; margin-left: 10px; width: calc(100% - 32px);">
+                        <span style="color: black; padding-top: 1px; width: 160px; flex-grow: 1; font-size: 14px; font-weight: 700; overflow: hidden; padding-right: 5px; text-overflow: ellipsis; white-space: nowrap;">${FileUtils.getName(attachment.filepath)}</span>
+                        <span style="color: #9b9b9b; flex-grow: 0; font-size: 13px; white-space: nowrap; line-height: 21px;">${FileUtils.readableFileSize(attachment.size)}</span>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+                """
         }
     }
 }

--- a/src/main/kotlin/com/criptext/mail/utils/HashUtils.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/HashUtils.kt
@@ -1,0 +1,14 @@
+package com.criptext.mail.utils
+
+import java.security.MessageDigest
+
+fun String.sha256(): String {
+    return this.hashWithAlgorithm("SHA-256")
+}
+
+private fun String.hashWithAlgorithm(algorithm: String): String {
+    val digest = MessageDigest.getInstance(algorithm)
+    val bytes = digest.digest(this.toByteArray(Charsets.UTF_8))
+    return Encoding.byteArrayToString(bytes)
+}
+

--- a/src/main/res/layout/view_settings_general.xml
+++ b/src/main/res/layout/view_settings_general.xml
@@ -510,6 +510,10 @@
                 android:layout_marginStart="17dp"
                 android:layout_marginEnd="22dp"/>
 
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -518,6 +522,15 @@
                 android:gravity="center_vertical"
                 android:textColor="#b9b9b9"
                 android:layout_margin="17dp"/>
+            <TextView
+                android:id="@+id/version_text"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:textSize="@dimen/drawer_text_item"
+                android:gravity="center_vertical"
+                android:textColor="#b9b9b9"
+                android:layout_margin="17dp"/>
+            </LinearLayout>
 
         </LinearLayout>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <string name="separator_notifications">NOTIFICATIONS</string>
     <string name="separator_about">ABOUT</string>
     <string name="status_not_confirmed">Not Confirmed</string>
-    <string name="criptext_version">Criptext System Version 0.1</string>
+    <string name="criptext_version">Criptext System Version </string>
 
     <!-- LOGOUT DIALOG -->
     <string name="logout_dialog_message"><b>Alert!:</b> Login out will delete all emails from this device. Your emails will remain intact in your other devices, if any. Do you want to logout?</string>


### PR DESCRIPTION
- UNSEND on holders now removes checks
- Password hashed with SHA256
- Session for Guest Emails has change to reflect latest agreed format
- Now you can send attachments for unencrypted emails to non criptext users
- Thread multi select bug after marking as read/unread if the http requirement failed now fixed.
- On Logout if enpoint request fails, cancel logout, and dismiss dialog.
- Change logout request
- Added gradle version to settings  
- Change file upload/download to use the same jwt token as rest of workers.