### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 26
         versionCode 2
-        versionName "0.10.1"
+        versionName "0.10.2"
         applicationId "com.criptext.mail"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
@@ -189,6 +189,8 @@ dependencies {
     // file picker
 
     implementation 'com.github.jorgeblacio:Android-FilePicker:fixes-SNAPSHOT'
+
+    implementation 'com.madgag.spongycastle:core:1.54.0.0'
 
 }
 

--- a/src/main/kotlin/com/criptext/mail/BaseActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/BaseActivity.kt
@@ -37,6 +37,9 @@ import droidninja.filepicker.FilePickerBuilder
 import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper
 import java.io.File
 import java.util.*
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+
+
 
 
 /**
@@ -125,8 +128,10 @@ abstract class BaseActivity: AppCompatActivity(), IHostActivity {
         if (shouldCallSuper) super.onBackPressed()
     }
 
-    private fun startActivity(activityClass: Class<*>) {
+    private fun startActivity(activityClass: Class<*>, isExitCompletely: Boolean  = false) {
         val intent = Intent(this, activityClass)
+        if(isExitCompletely)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         startActivity(intent)
     }
 
@@ -164,21 +169,22 @@ abstract class BaseActivity: AppCompatActivity(), IHostActivity {
         return getString(message.resId, *message.args)
     }
 
-    override fun goToScene(params: SceneParams, keep: Boolean) {
+    override fun goToScene(params: SceneParams, keep: Boolean, deletePastIntents: Boolean) {
         val newSceneModel = createNewSceneFromParams(params)
         cachedModels[params.activityClass] = newSceneModel
-        startActivity(params.activityClass)
+        startActivity(params.activityClass, deletePastIntents)
 
         if (! keep) finish()
     }
 
-    override fun exitToScene(params: SceneParams, activityMessage: ActivityMessage?, forceAnimation: Boolean) {
+    override fun exitToScene(params: SceneParams, activityMessage: ActivityMessage?,
+                             forceAnimation: Boolean, deletePastIntents: Boolean) {
         BaseActivity.activityMessage = activityMessage
         finish()
         if(forceAnimation) {
             overridePendingTransition(0, R.anim.slide_out_right)
         }
-        goToScene(params, false)
+        goToScene(params, false, deletePastIntents)
     }
 
     override fun getIntentExtras(): IntentExtrasData? {

--- a/src/main/kotlin/com/criptext/mail/IHostActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/IHostActivity.kt
@@ -19,7 +19,7 @@ interface IHostActivity {
      * @param keep if true, the current activity will not be finished after the transition, so
      * that the user can return by pressing back.
      */
-    fun goToScene(params: SceneParams, keep: Boolean)
+    fun goToScene(params: SceneParams, keep: Boolean, deletePastIntents: Boolean = false)
 
     /**
      * Finishes the current activity and opens a new one using a "return" animation.
@@ -29,7 +29,7 @@ interface IHostActivity {
      * is useful when you want to return to an activity that already exists so params won't work.
      * @param forceAnimation a boolean to determinate if you want to force the slide_out_right animation.
      */
-    fun exitToScene(params: SceneParams, activityMessage: ActivityMessage?, forceAnimation: Boolean)
+    fun exitToScene(params: SceneParams, activityMessage: ActivityMessage?, forceAnimation: Boolean, deletePastIntents: Boolean = false)
     /**
      * Finishes the current activity.
      */

--- a/src/main/kotlin/com/criptext/mail/aes/AESUtil.kt
+++ b/src/main/kotlin/com/criptext/mail/aes/AESUtil.kt
@@ -1,6 +1,11 @@
 package com.criptext.mail.aes
 
 import com.criptext.mail.utils.Encoding
+import org.spongycastle.crypto.PBEParametersGenerator
+import org.spongycastle.crypto.digests.SHA256Digest
+import org.spongycastle.crypto.generators.PKCS5S2ParametersGenerator
+import org.spongycastle.crypto.params.KeyParameter
+import java.security.NoSuchAlgorithmException
 import java.security.SecureRandom
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -55,10 +60,12 @@ class AESUtil(keyAndIV: String) {
             val salt = ByteArray(8)
             val srandom = SecureRandom()
             srandom.nextBytes(salt)
-            val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
-            val spec = PBEKeySpec(password.toCharArray(), salt, 10000, 128)
-            val tmp = factory.generateSecret(spec)
-            val skey = SecretKeySpec(tmp.encoded, "AES")
+
+            val generator = PKCS5S2ParametersGenerator(SHA256Digest())
+            generator.init(PBEParametersGenerator.PKCS5PasswordToUTF8Bytes(password.toCharArray()), salt, 10000)
+            val key = generator.generateDerivedMacParameters(128) as KeyParameter
+
+            val skey = SecretKeySpec(key.key, "AES")
 
             val iv = ByteArray(128 / 8)
             srandom.nextBytes(iv)

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
@@ -187,7 +187,7 @@ class SettingsController(
     private fun onLogout(result: SettingsResult.Logout){
         when(result) {
             is SettingsResult.Logout.Success -> {
-                host.goToScene(SignInParams(), false)
+                host.exitToScene(SignInParams(), null, false, true)
             }
             is SettingsResult.Logout.Failure -> {
                 scene.dismissLoginOutDialog()
@@ -207,6 +207,17 @@ class SettingsController(
                         settingsUIObserver = settingsUIObserver)
             }
             is SettingsResult.ListDevices.Failure -> {
+                model.devices.clear()
+                model.devices.add(DeviceItem(
+                        id = activeAccount.deviceId.toLong(),
+                        friendlyName = DeviceUtils.getDeviceName(),
+                        name = DeviceUtils.getDeviceName(),
+                        isCurrent = true,
+                        deviceType = DeviceUtils.getDeviceType().ordinal))
+                scene.attachView(
+                        name = activeAccount.name,
+                        model = model,
+                        settingsUIObserver = settingsUIObserver)
                 scene.showMessage(UIMessage(R.string.error_listing_devices))
             }
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
@@ -2,9 +2,11 @@ package com.criptext.mail.scenes.settings.views
 
 import android.content.res.Resources
 import android.view.View
+import android.widget.Switch
 import android.widget.TextView
 import com.criptext.mail.BuildConfig
 import com.criptext.mail.R
+import com.criptext.mail.db.KeyValueStorage
 import com.criptext.mail.scenes.settings.SettingsUIObserver
 import com.criptext.mail.utils.ui.TabView
 import kotlinx.android.synthetic.main.deckard.view.*

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/SignInActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/SignInActivity.kt
@@ -34,7 +34,7 @@ class SignInActivity : BaseActivity() {
                 host = this,
                 dataSource = SignInDataSource(
                         runner = AsyncTaskWorkRunner(),
-                        keyGenerator = SignalKeyGenerator.Default(DeviceUtils.getDeviceType(appCtx)),
+                        keyGenerator = SignalKeyGenerator.Default(DeviceUtils.getDeviceType()),
                         httpClient = HttpClient.Default(),
                         signUpDao = appDB.signUpDao(),
                         keyValueStorage = KeyValueStorage.SharedPrefs(appCtx),

--- a/src/main/kotlin/com/criptext/mail/scenes/signup/SignUpActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signup/SignUpActivity.kt
@@ -26,7 +26,7 @@ class SignUpActivity: BaseActivity() {
 
     override fun initController(receivedModel: Any): SceneController {
         val appDB = AppDatabase.getAppDatabase(this.applicationContext)
-        val signalKeyGenerator = SignalKeyGenerator.Default(DeviceUtils.getDeviceType(this.applicationContext))
+        val signalKeyGenerator = SignalKeyGenerator.Default(DeviceUtils.getDeviceType())
         val signUpSceneView = SignUpScene.SignUpSceneView(findViewById(R.id.signup_layout_container))
         val signUpSceneModel = receivedModel as SignUpSceneModel
         val keyValueStorage = KeyValueStorage.SharedPrefs(this)

--- a/src/main/kotlin/com/criptext/mail/utils/DeviceUtils.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/DeviceUtils.kt
@@ -29,7 +29,7 @@ class DeviceUtils{
                 Character.toUpperCase(first) + s.substring(1)
             }
         }
-        fun getDeviceType(context: Context): DeviceType {
+        fun getDeviceType(): DeviceType {
             return DeviceType.Android
         }
     }

--- a/src/main/res/layout/view_settings_general.xml
+++ b/src/main/res/layout/view_settings_general.xml
@@ -271,7 +271,8 @@
                 android:textSize="14sp"
                 android:gravity="center_vertical"
                 android:textColor="#6a707e"
-                android:paddingStart="17dp"/>
+                android:paddingStart="17dp"
+                android:visibility="gone"/>
 
             <FrameLayout
                 android:layout_width="match_parent"
@@ -283,7 +284,8 @@
                 android:layout_marginBottom="10dp"
                 android:id="@+id/settings_notifications"
                 android:clickable="true"
-                android:foreground="?attr/selectableItemBackground">
+                android:foreground="?attr/selectableItemBackground"
+                android:visibility="gone">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -316,12 +318,12 @@
 
             <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="40dp"
+                android:layout_height="60dp"
                 android:layout_gravity="center_vertical"
                 android:orientation="horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
                 android:paddingStart="17dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="10dp"
                 android:id="@+id/settings_privacy_policy"
                 android:clickable="true"
                 android:foreground="?attr/selectableItemBackground">
@@ -346,14 +348,21 @@
 
             </FrameLayout>
 
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:background="#d8d8d8"
+                android:layout_marginStart="17dp"
+                android:layout_marginEnd="22dp"/>
+
             <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="40dp"
+                android:layout_height="60dp"
                 android:layout_gravity="center_vertical"
                 android:orientation="horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
                 android:paddingStart="17dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="10dp"
                 android:id="@+id/settings_terms_of_service"
                 android:clickable="true"
                 android:foreground="?attr/selectableItemBackground">
@@ -378,14 +387,21 @@
 
             </FrameLayout>
 
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:background="#d8d8d8"
+                android:layout_marginStart="17dp"
+                android:layout_marginEnd="22dp"/>
+
             <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="40dp"
+                android:layout_height="60dp"
                 android:layout_gravity="center_vertical"
                 android:orientation="horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
                 android:paddingStart="17dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="10dp"
                 android:id="@+id/settings_open_source_libraries"
                 android:clickable="true"
                 android:foreground="?attr/selectableItemBackground">
@@ -410,14 +426,21 @@
 
             </FrameLayout>
 
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:background="#d8d8d8"
+                android:layout_marginStart="17dp"
+                android:layout_marginEnd="22dp"/>
+
             <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="40dp"
+                android:layout_height="60dp"
                 android:layout_gravity="center_vertical"
                 android:orientation="horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
                 android:paddingStart="17dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="10dp"
                 android:id="@+id/settings_logout"
                 android:clickable="true"
                 android:foreground="?attr/selectableItemBackground">

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -246,7 +246,7 @@
     <string name="error_getting_account">Error getting user account. Please try again</string>
     <string name="error_updating_account">Error updating user account. Please try again</string>
     <string name="error_login_out">Error login out. Please try again</string>
-    <string name="error_listing_devices">Error getting your device list from the server. Please try again</string>
+    <string name="error_listing_devices">Error getting your device list from the server.</string>
     <string name="error_updating_signature">Error updating user signature. Please try again</string>
     <string name="error_getting_labels">Error getting labels. Please try again</string>
     <string name="error_creating_labels">Error creating a label. Please try again</string>

--- a/src/test/java/com/criptext/mail/mocks/MockedIHostActivity.kt
+++ b/src/test/java/com/criptext/mail/mocks/MockedIHostActivity.kt
@@ -20,7 +20,8 @@ class MockedIHostActivity: IHostActivity{
     var isFinished: Boolean = false
     var activityLaunched: Boolean = false
 
-    override fun exitToScene(params: SceneParams, activityMessage: ActivityMessage?, forceAnimation: Boolean) {
+    override fun exitToScene(params: SceneParams, activityMessage: ActivityMessage?, forceAnimation: Boolean,
+                             deletePastIntents: Boolean) {
         isFinished = true
     }
 
@@ -33,7 +34,7 @@ class MockedIHostActivity: IHostActivity{
     override fun refreshToolbarItems() {
     }
 
-    override fun goToScene(params: SceneParams, keep: Boolean) {
+    override fun goToScene(params: SceneParams, keep: Boolean, deletePastIntents: Boolean) {
     }
 
     override fun finishScene() {


### PR DESCRIPTION
- Button Highlights on Settings-General view are now in the standard size.
- Pressing back after logout now won{t try to show the mailbox.
- On some devices using AES with PBKDF2WithHmacSHA256 was crashing the app when sending external encrypted emails, now if the device doesn't support PBKDF2WithHmacSHA256 we fallback to PBKDF2WithHmacSHA1.
- When listing devices failed, whether it was because of no internet connection or something that went wrong with the process, the settings were not displaying. Now they display and only list your current device and the snack bar tells the user that the app was unable to load his/her devices from the server.
