### PR TITLE
Added various small fixes.

### DIFF
--- a/src/main/kotlin/com/criptext/mail/scenes/settings/NewPasswordDialog.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/NewPasswordDialog.kt
@@ -65,25 +65,26 @@ class NewPasswordDialog(val context: Context) {
                              observer: SettingsUIObserver?): AlertDialog {
 
         val width = res.getDimension(R.dimen.non_criptext_email_send_dialog_width).toInt()
-        val nonCriptextEmailSendDialog = dialogBuilder.create()
-        val window = nonCriptextEmailSendDialog.window
-        nonCriptextEmailSendDialog.show()
+        val changePasswordDialog = dialogBuilder.create()
+        val window = changePasswordDialog.window
+        changePasswordDialog.show()
         window.setLayout(width, LinearLayout.LayoutParams.WRAP_CONTENT)
         window.setGravity(Gravity.CENTER_VERTICAL)
         val drawableBackground = ContextCompat.getDrawable(view.context,
                 R.drawable.dialog_label_chooser_shape)
-        nonCriptextEmailSendDialog.window.setBackgroundDrawable(drawableBackground)
+        changePasswordDialog.window.setBackgroundDrawable(drawableBackground)
+        changePasswordDialog.setCanceledOnTouchOutside(false)
 
         initializeLayoutComponents()
 
         //Assign event listeners
-        assignButtonEvents(view, nonCriptextEmailSendDialog, observer)
+        assignButtonEvents(view, changePasswordDialog, observer)
         assignOldPasswordTextListener()
         assignPasswordTextListener()
         assignConfirmPasswordTextChangeListener()
 
 
-        return nonCriptextEmailSendDialog
+        return changePasswordDialog
     }
 
     private fun initializeLayoutComponents(){
@@ -228,10 +229,11 @@ class NewPasswordDialog(val context: Context) {
                                    observer: SettingsUIObserver?) {
 
         btnSend.setOnClickListener {
-                uiObserver?.onOkChangePasswordDialogButton()
+            uiObserver?.onOkChangePasswordDialogButton()
         }
 
         btnCancel.setOnClickListener {
+            uiObserver?.onCancelChangePasswordButton()
             dialog.dismiss()
         }
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
@@ -93,7 +93,12 @@ class SettingsController(
         }
 
         override fun onOkChangePasswordDialogButton() {
+            keyboardManager.hideKeyboard()
             dataSource.submitRequest(SettingsRequest.ChangePassword(model.oldPasswordText, model.confirmPasswordText))
+        }
+
+        override fun onCancelChangePasswordButton() {
+            keyboardManager.hideKeyboard()
         }
 
         override fun onChangePasswordOptionClicked() {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsLogoutDialog.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsLogoutDialog.kt
@@ -1,6 +1,7 @@
 package com.criptext.mail.scenes.settings
 
 import android.content.Context
+import android.os.CountDownTimer
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
@@ -54,6 +55,8 @@ class SettingsLogoutDialog(val context: Context) {
                                    observer: SettingsUIObserver?) {
 
         val btn_yes = view.findViewById(R.id.settings_logout_yes) as Button
+        btn_yes.isEnabled = false
+        timerListener(btn_yes,10000)
         val btn_no = view.findViewById(R.id.settings_logout_cancel) as Button
 
         btn_yes.setOnClickListener {
@@ -64,5 +67,20 @@ class SettingsLogoutDialog(val context: Context) {
         btn_no.setOnClickListener {
             dialog.dismiss()
         }
+    }
+
+    private fun timerListener(button: Button, startTime: Long) {
+        object : CountDownTimer(startTime, 1000) {
+
+            override fun onTick(millisUntilFinished: Long) {
+                val sec = ((millisUntilFinished / 1000) % 60).toInt()
+                button.text = context.getString(R.string.yes_with_time, sec)
+            }
+
+            override fun onFinish() {
+                button.setText(R.string.yes)
+                button.isEnabled = true
+            }
+        }.start()
     }
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsUIObserver.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsUIObserver.kt
@@ -24,6 +24,7 @@ interface SettingsUIObserver: UIObserver {
     fun onPasswordChangedListener(password: String)
     fun onConfirmPasswordChangedListener(confirmPassword: String)
     fun onOkChangePasswordDialogButton()
+    fun onCancelChangePasswordButton()
     fun onProfileNameChanged(fullName: String)
     fun onCustomLabelNameAdded(labelName: String)
     fun onCreateLabelClicked()

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/change_email/ChangeEmailController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/change_email/ChangeEmailController.kt
@@ -70,7 +70,7 @@ class ChangeEmailController(
     }
 
     private fun toggleChangeEmailButton() {
-        if(model.newRecoveryEmail.state !is FormInputState.Error
+        if(model.newRecoveryEmail.state is FormInputState.Valid
                 && model.newRecoveryEmail.value != model.recoveryEmail) {
             scene.enableChangeButton()
         } else {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/LogoutWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/LogoutWorker.kt
@@ -34,7 +34,7 @@ class LogoutWorker(
     }
 
     override fun work(reporter: ProgressReporter<SettingsResult.Logout>): SettingsResult.Logout? {
-        val deleteOperation = Result.of {apiClient.deleteDevice(activeAccount.deviceId)}
+        val deleteOperation = Result.of {apiClient.postLogout()}
                 .mapError(HttpErrorHandlingHelper.httpExceptionsToNetworkExceptions)
         return when (deleteOperation){
             is Result.Success -> {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsAPIClient.kt
@@ -57,4 +57,8 @@ class SettingsAPIClient(private val httpClient: HttpClient, private val token: S
         return httpClient.delete(path = "/device/$deviceId", authToken = token)
     }
 
+    fun postLogout(): String{
+        return httpClient.post(path = "/user/logout", authToken = token, body = JSONObject())
+    }
+
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
@@ -53,7 +53,7 @@ class SignInSceneController(
         scene.toggleForgotPasswordClickable(true)
         when(result){
             is SignInResult.ForgotPassword.Success -> scene.showError(UIMessage(R.string.forgot_password_message))
-            is SignInResult.ForgotPassword.Failure -> scene.showError(UIMessage(R.string.forgot_password_error))
+            is SignInResult.ForgotPassword.Failure -> scene.showError(result.message)
         }
     }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInResult.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInResult.kt
@@ -29,6 +29,7 @@ sealed class SignInResult {
 
     sealed class ForgotPassword: SignInResult() {
         class Success: ForgotPassword()
-        class Failure: ForgotPassword()
+        data class Failure(val message: UIMessage,
+                val exception: Exception): ForgotPassword()
     }
 }

--- a/src/main/kotlin/com/criptext/mail/utils/ServerErrorCodes.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/ServerErrorCodes.kt
@@ -1,6 +1,7 @@
 package com.criptext.mail.utils
 
 object ServerErrorCodes{
+    const val BadRequest = 400
     const val Unauthorized = 401
     const val Forbidden = 403
 }

--- a/src/main/kotlin/com/criptext/mail/utils/remotechange/data/DeviceRemovedWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/remotechange/data/DeviceRemovedWorker.kt
@@ -28,7 +28,7 @@ class DeviceRemovedWorker(private val letAPIKnow: Boolean,
     override fun work(reporter: ProgressReporter<RemoteChangeResult.DeviceRemoved>)
             : RemoteChangeResult.DeviceRemoved? {
 
-        val deleteOperation = if(letAPIKnow) { Result.of { apiClient.deleteDevice(activeAccount.deviceId) }
+        val deleteOperation = if(letAPIKnow) { Result.of { apiClient.postLogout() }
                 .flatMap { Result.of { RemoveDeviceUtils.removeDevice(db, storage) }}}
         else
             Result.of { RemoveDeviceUtils.removeDevice(db, storage) }

--- a/src/main/kotlin/com/criptext/mail/utils/remotechange/data/RemoteChangeAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/remotechange/data/RemoteChangeAPIClient.kt
@@ -15,4 +15,8 @@ class RemoteChangeAPIClient(private val httpClient: HttpClient, private val toke
         return httpClient.delete(path = "/device/$deviceId", authToken = token)
     }
 
+    fun postLogout(): String{
+        return httpClient.post(path = "/user/logout", authToken = token, body = JSONObject())
+    }
+
 }

--- a/src/main/res/drawable/error_circle_2.xml
+++ b/src/main/res/drawable/error_circle_2.xml
@@ -1,0 +1,9 @@
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="ring"
+    android:thickness="1dp"
+    android:useLevel="false"
+    >
+    <solid android:color="@color/red" />
+
+</shape>

--- a/src/main/res/drawable/success_circle_2.xml
+++ b/src/main/res/drawable/success_circle_2.xml
@@ -1,0 +1,9 @@
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="ring"
+    android:thickness="1dp"
+    android:useLevel="false"
+    >
+    <solid android:color="@color/colorAccent" />
+
+</shape>

--- a/src/main/res/layout/activity_change_email.xml
+++ b/src/main/res/layout/activity_change_email.xml
@@ -57,66 +57,70 @@
         android:orientation="vertical">
 
         <TextView
+            fontPath="fonts/NunitoSans-Regular.ttf"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/change_email_title"
             android:textColor="#373a45"
-            android:textSize="18sp"
-            fontPath="fonts/NunitoSans-Regular.ttf"/>
+            android:textSize="18sp" />
 
         <RelativeLayout
             android:id="@+id/edit_text_layout"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginTop="10dp"
-            android:layout_height="wrap_content">
+            android:layout_marginTop="10dp">
 
             <FrameLayout
-                android:layout_marginTop="15dp"
-                android:layout_marginStart="5dp"
-                android:layout_marginEnd="3dp"
                 android:layout_width="30dp"
-                android:layout_toStartOf="@+id/recovery_email_input"
-                android:layout_height="30dp">
+                android:layout_height="30dp"
+                android:layout_marginEnd="3dp"
+                android:layout_marginTop="15dp"
+                android:layout_toStartOf="@+id/input_layout">
+
                 <ImageView
                     android:id="@+id/error"
-                    android:visibility="invisible"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@drawable/error_circle_2"
                     android:src="@drawable/x_rounded"
                     android:tint="@color/red"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"/>
+                    android:visibility="invisible" />
+
                 <ImageView
                     android:id="@+id/success"
-                    android:visibility="invisible"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center|start"
+                    android:background="@drawable/success_circle_2"
+                    android:padding="5dp"
                     android:src="@drawable/check"
                     android:tint="@color/colorOpened"
-                    android:padding="9dp"
-                    android:layout_gravity="center|start"
-                    android:background="@drawable/success_circle"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"/>
+                    android:visibility="invisible" />
 
             </FrameLayout>
 
 
             <android.support.design.widget.TextInputLayout
                 android:id="@+id/input_layout"
-                android:layout_width="260dp"
+                android:layout_width="300dp"
                 android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentTop="true"
+                android:layout_gravity="top|center_horizontal"
+                android:layout_marginEnd="0dp"
                 android:textColorHint="@color/signup_hint_color"
-                app:hintTextAppearance="@style/NormalTextAppearence"
-                app:errorTextAppearance="@style/textinputlayout_error_non_criptext_email_send"
-                android:layout_centerHorizontal="true"
                 app:errorEnabled="true"
-                android:layout_gravity="top|center_horizontal">
+                app:errorTextAppearance="@style/textinputlayout_error_non_criptext_email_send"
+                app:hintTextAppearance="@style/NormalTextAppearence">
 
                 <android.support.design.widget.TextInputEditText
                     android:id="@+id/input"
-                    android:textSize="15sp"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:inputType="textEmailAddress"
-                    android:singleLine="true"/>
+                    android:singleLine="true"
+                    android:textSize="15sp" />
 
             </android.support.design.widget.TextInputLayout>
 
@@ -128,10 +132,10 @@
             android:layout_height="40dp"
             android:layout_gravity="end"
             android:background="@drawable/btn_welcome_tour"
-            android:textColor="@color/white"
+            android:enabled="false"
             android:text="@string/button_change_email_confirm"
             android:textAllCaps="false"
-            android:enabled="false"/>
+            android:textColor="@color/white" />
 
 
     </LinearLayout>

--- a/src/main/res/layout/settings_custom_logout_dialog.xml
+++ b/src/main/res/layout/settings_custom_logout_dialog.xml
@@ -51,7 +51,7 @@
             android:text="@string/cancel" />
 
         <Button
-            android:textColor="@color/label_buttons_text"
+            android:textColor="@color/button_text_color"
             fontPath="fonts/NunitoSans-Bold.ttf"
             android:textSize="15sp"
             android:textAllCaps="false"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="title_open_source_libraries">Open Source Libraries</string>
     <string name="title_logout">Logout</string>
     <string name="title_remove_device">Remove Device</string>
-    <string name="title_enter_password">Enter your password to continue</string>
+    <string name="title_enter_password">Enter your password\nto continue</string>
     <string name="title_custom_dialog">New Label</string>
     <string name="hint_custom_dialog">Enter the name</string>
     <string name="title_profile_photo">Profile Photo</string>
@@ -122,6 +122,7 @@
     <!-- FORGOT PASSWORD -->
     <string name="forgot_password_message">A reset link for your password has been sent to your recovery email address</string>
     <string name="forgot_password_error">Error contacting the server, try again later</string>
+    <string name="forgot_password_error_400">A recovery email address has not been set up for this account, without it you cannot reset the password</string>
 
     <!-- CHANGE PASSWORD DIALOG -->
     <string name="title_change_password_dialog">Change password</string>
@@ -268,6 +269,7 @@
     <string name="txt_create_criptext_account">Create your Criptext account</string>
     <string name="password_login_content">You can also login using your\npassword, however you won\'t have\naccess to any email history that\'s\nstored on your verified devices.</string>
     <string name="yes">Yes</string>
+    <string name="yes_with_time">Yes(%1$d)</string>
     <string name="discard">Discard</string>
 
     <!-- LOGIN ERRORS -->


### PR DESCRIPTION
- Added error display for the user if the recovery email hasn't been set and tries to reset his/her password.
- Change a validation that was allowing to try to change the recovery email with an empty text box.
- Changed the calls to removeDevice endpoint to logout were it was needed.
- The keyboard was not hiding after interacting with the ChangePassword Dialog
- Better object alignment for the Recovery Email Change screen.
- Added circles for the error and success images for recovery email change screen.
- Added a 10 second timer to the logout "Yes" button before enabling it.