### PR TITLE
Various fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 26
-        versionCode 10
-        versionName "0.10.9"
+        versionCode 11
+        versionName "0.11.0"
         applicationId "com.criptext.mail"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/src/main/kotlin/com/criptext/mail/BaseActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/BaseActivity.kt
@@ -4,10 +4,8 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.provider.MediaStore
 import android.support.annotation.VisibleForTesting
 import android.support.v4.app.ActivityCompat
-import android.support.v4.content.FileProvider
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import android.view.Menu
@@ -37,8 +35,10 @@ import droidninja.filepicker.FilePickerBuilder
 import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper
 import java.io.File
 import java.util.*
-import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import com.criptext.mail.scenes.settings.SettingsActivity
+import com.criptext.mail.scenes.settings.change_email.ChangeEmailActivity
 import com.criptext.mail.scenes.settings.change_email.ChangeEmailModel
+import com.criptext.mail.scenes.settings.recovery_email.RecoveryEmailActivity
 import com.criptext.mail.scenes.settings.recovery_email.RecoveryEmailModel
 
 
@@ -268,6 +268,7 @@ abstract class BaseActivity: AppCompatActivity(), IHostActivity {
             cachedModels[MailboxActivity::class.java] = MailboxSceneModel()
             cachedModels[SignInActivity::class.java] = SignInSceneModel()
             cachedModels[SignUpActivity::class.java] = SignUpSceneModel()
+            cachedModels[SettingsActivity::class.java] = SettingsModel()
         }
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/src/main/kotlin/com/criptext/mail/api/JSONData.kt
+++ b/src/main/kotlin/com/criptext/mail/api/JSONData.kt
@@ -19,8 +19,15 @@ interface JSONData {
 
 }
 
-fun List<Long>.toJSONLongArray(): JSONArray {
+fun List<Long>.toJSONLongArray():
+        JSONArray {
         val jsonArray = JSONArray()
         this.forEach { jsonArray.put(it) }
         return jsonArray
     }
+
+fun <T> JSONArray.toList(): List<T> {
+    val list = mutableListOf<T>()
+    for(i in 0 until this.length()) list.add(this[i] as T)
+    return list
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/data/SaveEmailWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/data/SaveEmailWorker.kt
@@ -68,9 +68,9 @@ class SaveEmailWorker(
 
         return EmailMetadata.DBColumns(messageId = draftMessageId,
                 threadId = threadId ?: draftMessageId, subject = composerInputData.subject,
-                to = composerInputData.to.toCSVEmails(),
-                cc = composerInputData.cc.toCSVEmails(),
-                bcc = composerInputData.bcc.toCSVEmails(),
+                to = composerInputData.to.map { it.email },
+                cc = composerInputData.cc.map { it.email },
+                bcc = composerInputData.bcc.map { it.email },
                 date = DateUtils.printDateWithServerFormat(Date()),
                 unsentDate = DateUtils.printDateWithServerFormat(Date()),
                 metadataKey = System.currentTimeMillis(), // ugly hack because we don't have draft table

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailSceneController.kt
@@ -619,7 +619,10 @@ class EmailDetailSceneController(private val scene: EmailDetailScene,
         }
 
         override fun onNewEmail(email: Email) {
-            scene.notifyFullEmailListChanged()
+            if(email.threadId == model.threadId){
+                dataSource.submitRequest(EmailDetailRequest.LoadFullEmailsFromThreadId(
+                        email.threadId, model.currentLabel))
+            }
         }
 
         override fun onNewTrackingUpdate(emailId: Long, update: TrackingUpdate) {

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxActivity.kt
@@ -42,7 +42,7 @@ class MailboxActivity : BaseActivity() {
         (1..50)
           .forEach {
               val seconds = if (it < 10) "0$it" else it.toString()
-              val metadata = EmailMetadata.DBColumns(to = "gabriel@jigl.com",  cc = "", bcc = "",
+              val metadata = EmailMetadata.DBColumns(to = listOf("gabriel@jigl.com"),  cc = emptyList(), bcc = emptyList(),
                       fromContact = fromContact, messageId = "gabriel/1/$it",
                       date = "2018-02-21 14:00:$seconds",unsentDate = "2018-02-21 14:00:$seconds", threadId = "thread#$it",
                       subject = "Test #$it", unread = true, metadataKey = 1 + 100,

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
@@ -61,6 +61,7 @@ class SettingsController(
             is SettingsResult.GetUserSettings -> onGetUserSettings(result)
             is SettingsResult.RemoveDevice -> onRemoveDevice(result)
             is SettingsResult.ChangePassword -> onChangePassword(result)
+            is SettingsResult.ResetPassword -> onResetPassword(result)
         }
     }
 
@@ -74,7 +75,7 @@ class SettingsController(
         }
 
         override fun onRecoveryEmailOptionClicked() {
-            host.goToScene(RecoveryEmailParams(model.isEmailCconfirmed, model.recoveryEmail), false)
+            host.goToScene(RecoveryEmailParams(model.isEmailConfirmed, model.recoveryEmail), false)
         }
 
         override fun onOldPasswordChangedListener(password: String) {
@@ -103,6 +104,11 @@ class SettingsController(
 
         override fun onChangePasswordOptionClicked() {
             scene.showChangePasswordDialog()
+        }
+
+        override fun onResetPasswordOptionClicked() {
+            scene.isSendingResetPassword(true)
+            dataSource.submitRequest(SettingsRequest.ResetPassword())
         }
 
         override fun onCustomLabelNameAdded(labelName: String) {
@@ -341,7 +347,7 @@ class SettingsController(
             is SettingsResult.GetUserSettings.Success -> {
                 model.devices.clear()
                 model.devices.addAll(result.userSettings.devices)
-                model.isEmailCconfirmed = result.userSettings.recoveryEmailConfirmationState
+                model.isEmailConfirmed = result.userSettings.recoveryEmailConfirmationState
                 model.recoveryEmail = result.userSettings.recoveryEmail
                 deviceWrapperListController.update()
                 scene.updateUserSettings(result.userSettings)
@@ -379,7 +385,19 @@ class SettingsController(
                 scene.showMessage(UIMessage(R.string.change_password_success))
             }
             is SettingsResult.ChangePassword.Failure -> {
-                scene.setConfirmPasswordError(UIMessage(R.string.password_enter_error))
+                scene.showOldPasswordDialogError(UIMessage(R.string.password_enter_error))
+            }
+        }
+    }
+
+    private fun onResetPassword(result: SettingsResult.ResetPassword){
+        scene.isSendingResetPassword(false)
+        when(result) {
+            is SettingsResult.ResetPassword.Success -> {
+                scene.showMessage(UIMessage(R.string.forgot_password_message))
+            }
+            is SettingsResult.ResetPassword.Failure -> {
+                scene.showMessage(result.message)
             }
         }
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsModel.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsModel.kt
@@ -15,6 +15,6 @@ class SettingsModel{
     var confirmPasswordText: String = ""
     var passwordState: FormInputState = FormInputState.Unknown()
 
-    var isEmailCconfirmed: Boolean = false
+    var isEmailConfirmed: Boolean = false
     var recoveryEmail: String = ""
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsScene.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsScene.kt
@@ -45,6 +45,7 @@ interface SettingsScene{
     fun setConfirmPasswordError(message: UIMessage)
     fun setRemoveDeviceError(message: UIMessage)
     fun removeDeviceDialogToggleLoad(loading: Boolean)
+    fun isSendingResetPassword(isSending: Boolean)
     fun removeDeviceDialogDismiss()
 
 
@@ -180,6 +181,10 @@ interface SettingsScene{
 
         override fun removeDeviceDialogToggleLoad(loading: Boolean) {
             settingRemoveDeviceDialog.toggleLoad(loading)
+        }
+
+        override fun isSendingResetPassword(isSending: Boolean) {
+            generalView.isSendingResetPassword(isSending)
         }
 
         override fun removeDeviceDialogDismiss() {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsUIObserver.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsUIObserver.kt
@@ -20,6 +20,7 @@ interface SettingsUIObserver: UIObserver {
     fun onRemoveDeviceCancel()
     fun onRemoveDevice(deviceId: Int, position: Int)
     fun onChangePasswordOptionClicked()
+    fun onResetPasswordOptionClicked()
     fun onRecoveryEmailOptionClicked()
     fun onOldPasswordChangedListener(password: String)
     fun onPasswordChangedListener(password: String)

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/ForgotPasswordWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/ForgotPasswordWorker.kt
@@ -1,0 +1,56 @@
+package com.criptext.mail.scenes.settings.data
+
+import android.accounts.NetworkErrorException
+import com.criptext.mail.R
+import com.criptext.mail.api.HttpClient
+import com.criptext.mail.api.ServerErrorException
+import com.criptext.mail.bgworker.BackgroundWorker
+import com.criptext.mail.bgworker.ProgressReporter
+import com.criptext.mail.db.models.ActiveAccount
+import com.criptext.mail.scenes.signup.data.SignUpAPIClient
+import com.criptext.mail.scenes.signup.data.SignUpResult
+import com.criptext.mail.utils.ServerErrorCodes
+import com.criptext.mail.utils.UIMessage
+import com.github.kittinunf.result.Result
+import org.json.JSONException
+
+
+class ForgotPasswordWorker(val httpClient: HttpClient,
+                           val activeAccount: ActiveAccount,
+                           override val publishFn: (SettingsResult) -> Unit)
+    : BackgroundWorker<SettingsResult.ResetPassword> {
+
+    private val apiClient = SettingsAPIClient(httpClient, activeAccount.jwt)
+
+    override val canBeParallelized = true
+
+    override fun catchException(ex: Exception): SettingsResult.ResetPassword {
+        return SettingsResult.ResetPassword.Failure(createErrorMessage(ex))
+    }
+
+    override fun work(reporter: ProgressReporter<SettingsResult.ResetPassword>): SettingsResult.ResetPassword? {
+        val result = Result.of { apiClient.postForgotPassword(activeAccount.recipientId) }
+
+        return when (result) {
+            is Result.Success -> SettingsResult.ResetPassword.Success()
+            is Result.Failure -> catchException(result.error)
+        }
+
+    }
+
+    override fun cancel() {
+        TODO("not implemented") //To change body of created functions use CRFile | Settings | CRFile Templates.
+    }
+
+    private val createErrorMessage: (ex: Exception) -> UIMessage = { ex ->
+        when (ex) {
+            is ServerErrorException ->
+                if(ex.errorCode == ServerErrorCodes.BadRequest)
+                UIMessage(resId = R.string.forgot_password_error_400)
+                else
+                    UIMessage(resId = R.string.forgot_password_error)
+            else ->UIMessage(resId = R.string.forgot_password_error)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsAPIClient.kt
@@ -62,4 +62,11 @@ class SettingsAPIClient(private val httpClient: HttpClient, private val token: S
         return httpClient.post(path = "/user/logout", authToken = token, body = JSONObject())
     }
 
+    fun postForgotPassword(recipientId: String): String{
+        val jsonPut = JSONObject()
+        jsonPut.put("recipientId", recipientId)
+
+        return httpClient.post(path = "/user/password/reset", authToken = null, body = jsonPut)
+    }
+
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsDataSource.kt
@@ -72,6 +72,11 @@ class SettingsDataSource(
                     httpClient = httpClient,
                     publishFn = { res -> flushResults(res) }
             )
+            is SettingsRequest.ResetPassword -> ForgotPasswordWorker(
+                    activeAccount = activeAccount,
+                    httpClient = httpClient,
+                    publishFn = { res -> flushResults(res) }
+            )
         }
     }
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsRequest.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsRequest.kt
@@ -7,6 +7,7 @@ sealed class SettingsRequest{
     data class RemoveDevice(val deviceId: Int, val position: Int, val password: String): SettingsRequest()
     data class ChangePassword(val oldPassword: String, val newPassword: String): SettingsRequest()
     class GetUserSettings: SettingsRequest()
+    class ResetPassword: SettingsRequest()
     data class CreateCustomLabel(val labelName: String): SettingsRequest()
     data class ChangeVisibilityLabel(val labelId: Long, val isVisible: Boolean): SettingsRequest()
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsResult.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/data/SettingsResult.kt
@@ -38,6 +38,11 @@ sealed class SettingsResult{
         class Forbidden: GetUserSettings()
     }
 
+    sealed class ResetPassword : SettingsResult() {
+        class Success: ResetPassword()
+        data class Failure(val message: UIMessage): ResetPassword()
+    }
+
     sealed class RemoveDevice : SettingsResult() {
         class Success(val deviceId: Int, val position: Int): RemoveDevice()
         class Failure: RemoveDevice()

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
@@ -19,6 +19,8 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
     private lateinit var settingsChangePassword: View
     private lateinit var settingsRecoveryEmail: View
     private lateinit var settingsRecoveryEmailLoading: View
+    private lateinit var settingsResetPassword: View
+    private lateinit var settingsResetPasswordLoading: View
     private lateinit var settingsRecoveryEmailConfirmText: TextView
     private lateinit var versionText: TextView
 
@@ -37,12 +39,17 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
         settingsChangePassword = view.findViewById(R.id.settings_change_password)
         settingsRecoveryEmail = view.findViewById(R.id.settings_recovery)
         settingsRecoveryEmailLoading = view.findViewById(R.id.settings_recovery_loading)
+        settingsResetPassword = view.findViewById(R.id.settings_reset_password)
+        settingsResetPasswordLoading = view.findViewById(R.id.settings_reset_loading)
         settingsRecoveryEmailConfirmText = view.findViewById(R.id.not_confirmed_text) as TextView
         versionText = view.findViewById(R.id.version_text) as TextView
         versionText.text = BuildConfig.VERSION_NAME
 
         settingsRecoveryEmail.visibility = View.GONE
         settingsRecoveryEmailLoading.visibility = View.VISIBLE
+
+        settingsResetPasswordLoading.visibility = View.VISIBLE
+        settingsResetPassword.visibility = View.GONE
 
         setButtonListeners()
     }
@@ -54,6 +61,10 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
     fun setRecoveryEmailConfirmationText(isConfirmed: Boolean){
         settingsRecoveryEmail.visibility = View.VISIBLE
         settingsRecoveryEmailLoading.visibility = View.GONE
+
+        settingsResetPasswordLoading.visibility = View.GONE
+        settingsResetPassword.visibility = View.VISIBLE
+
         if(isConfirmed) {
             settingsRecoveryEmailConfirmText.setTextColor(ContextCompat.getColor(
                     view.context, R.color.green))
@@ -65,12 +76,25 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
         }
     }
 
+    fun isSendingResetPassword(isSending: Boolean){
+        if(isSending){
+            settingsResetPasswordLoading.visibility = View.VISIBLE
+            settingsResetPassword.visibility = View.GONE
+        }else{
+            settingsResetPasswordLoading.visibility = View.GONE
+            settingsResetPassword.visibility = View.VISIBLE
+        }
+    }
+
     private fun setButtonListeners(){
         settingsProfileName.setOnClickListener {
             settingsUIObserver?.onProfileNameClicked()
         }
         settingsChangePassword.setOnClickListener {
             settingsUIObserver?.onChangePasswordOptionClicked()
+        }
+        settingsResetPassword.setOnClickListener {
+            settingsUIObserver?.onResetPasswordOptionClicked()
         }
         settingsRecoveryEmail.setOnClickListener {
             settingsUIObserver?.onRecoveryEmailOptionClicked()

--- a/src/main/res/layout/remote_change_confirm_pasword_dialog.xml
+++ b/src/main/res/layout/remote_change_confirm_pasword_dialog.xml
@@ -9,7 +9,7 @@
         android:id="@+id/title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/title_enter_password"
+        android:text="@string/title_remote_change_password"
         fontPath="fonts/NunitoSans-SemiBold.ttf"
         android:gravity="center_horizontal"
         android:paddingTop="20dp"

--- a/src/main/res/layout/view_settings_general.xml
+++ b/src/main/res/layout/view_settings_general.xml
@@ -94,6 +94,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0.5dp"
                 android:background="#d8d8d8"
+                android:visibility="gone"
                 android:layout_marginStart="17dp"
                 android:layout_marginEnd="22dp"/>
 
@@ -134,7 +135,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="0.5dp"
                 android:background="#d8d8d8"
-                android:visibility="gone"
                 android:layout_marginStart="17dp"
                 android:layout_marginEnd="22dp"/>
 
@@ -155,6 +155,79 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:text="@string/title_change_password"
+                    android:textSize="@dimen/drawer_text_item"
+                    android:gravity="center_vertical"
+                    android:textColor="@color/drawer_text"/>
+
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="40dp"
+                    android:layout_marginEnd="10dp"
+                    android:scaleType="fitCenter"
+                    android:layout_gravity="end|center_vertical"
+                    android:padding="12dp"
+                    android:tint="#e3e3e3"
+                    android:src="@drawable/arrow_right"/>
+
+            </FrameLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:background="#d8d8d8"
+                android:visibility="visible"
+                android:layout_marginStart="17dp"
+                android:layout_marginEnd="22dp"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:paddingStart="17dp"
+                android:id="@+id/settings_reset_loading"
+                android:clickable="false"
+                android:visibility="gone"
+                android:foreground="?attr/selectableItemBackground">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:text="@string/title_reset_password"
+                    android:textSize="@dimen/drawer_text_item"
+                    android:gravity="center_vertical"
+                    android:textColor="@color/drawer_text"
+                    android:layout_weight="1"/>
+
+                <ProgressBar
+                    android:layout_width="25.6dp"
+                    android:layout_height="32dp"
+                    android:layout_marginEnd="20dp"
+                    android:scaleType="fitCenter"
+                    android:visibility="visible"
+                    android:layout_gravity="center_vertical"/>
+
+            </LinearLayout>
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:paddingStart="17dp"
+                android:id="@+id/settings_reset_password"
+                android:visibility="visible"
+                android:clickable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/title_reset_password"
                     android:textSize="@dimen/drawer_text_item"
                     android:gravity="center_vertical"
                     android:textColor="@color/drawer_text"/>
@@ -362,7 +435,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-                    android:text="@string/title_privacy_policies"
+                    android:text="@string/title_privacy_policy"
                     android:textSize="@dimen/drawer_text_item"
                     android:gravity="center_vertical"
                     android:textColor="@color/drawer_text"/>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <!-- SETTINGS -->
     <string name="title_swipe">Swipe Options</string>
     <string name="title_profile_name">Profile Name</string>
-    <string name="title_privacy_policies">Privacy Policies</string>
+    <string name="title_privacy_policy">Privacy Policy</string>
     <string name="title_terms_of_service">Terms of Service</string>
     <string name="title_open_source_libraries">Open Source Libraries</string>
     <string name="title_logout">Logout</string>
@@ -84,6 +84,7 @@
     <string name="hint_custom_dialog">Enter the name</string>
     <string name="title_profile_photo">Profile Photo</string>
     <string name="title_change_password">Change Password</string>
+    <string name="title_reset_password">Reset Password</string>
     <string name="title_recovery_email">Recovery Email</string>
     <string name="title_signature">Signature</string>
     <string name="title_signature_cap">SIGNATURE</string>
@@ -122,14 +123,15 @@
     <!-- FORGOT PASSWORD -->
     <string name="forgot_password_message">A reset link for your password has been sent to your recovery email address</string>
     <string name="forgot_password_error">Error contacting the server, try again later</string>
-    <string name="forgot_password_error_400">A recovery email address has not been set up for this account, without it you cannot reset the password</string>
+    <string name="forgot_password_error_400">A recovery email address has not been set up or confirmed for this account, without it you cannot reset the password</string>
 
     <!-- CHANGE PASSWORD DIALOG -->
     <string name="title_change_password_dialog">Change password</string>
 
     <!-- CONFIRM PASSWORD REMOTE CHANGE -->
-    <string name="remote_change_password_advice">Your password has changed remotely. Confirm your new password, if you Cancel, the device will logout and all local data will be erased.</string>
+    <string name="remote_change_password_advice">Confirm your new password.\nIf you Cancel, the device will logout and all local data <b>will be erased.</b></string>
     <string name="update_password_success">Password has been updated for this device.</string>
+    <string name="title_remote_change_password">Your password has changed\nremotely</string>
 
     <!-- LOGOUT DIALOG -->
     <string name="logout_dialog_message"><b>Alert!:</b> Login out will delete all emails from this device. Your emails will remain intact in your other devices, if any. Do you want to logout?</string>


### PR DESCRIPTION
- Added Reset Password option in General Settings
- Now if a new Email arrives while you are at the Email detail, and it belongs to that thread, the view updates with the new email.
- There was a really weird case in which you can put your name in gmail as < name@criptext.com >, this was causing major issues when parsing the incoming from address. 
- The incoming addresses in to, cc and bcc are now coming as lists, and the changes to handle this have been made, also fixed a weird naming issue for some incoming external addresses.
