### PR TITLE
Refactored link devices flow to not be solely dependant on web socket events.

### DIFF
--- a/src/main/kotlin/com/criptext/mail/BaseActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/BaseActivity.kt
@@ -160,7 +160,7 @@ abstract class BaseActivity: AppCompatActivity(), IHostActivity {
             is SignatureParams -> SignatureModel(params.recipientId)
             is RecoveryEmailParams -> RecoveryEmailModel(params.isConfirmed, params.recoveryEmail)
             is ChangePasswordParams -> ChangePasswordModel()
-            is LinkingParams -> LinkingModel(params.email)
+            is LinkingParams -> LinkingModel(params.email, params.deviceId, params.randomId)
             else -> throw IllegalArgumentException("Don't know how to create a model from ${params.javaClass}")
         }
     }

--- a/src/main/kotlin/com/criptext/mail/api/HttpClient.kt
+++ b/src/main/kotlin/com/criptext/mail/api/HttpClient.kt
@@ -21,7 +21,7 @@ interface HttpClient {
     fun get(path: String, authToken: String?): String
     fun delete(path: String, authToken: String?, body: JSONObject): String
     fun getFile(path: String, authToken: String?): ByteArray
-    fun postFileStream(path: String, authToken: String?, filePath: String): String
+    fun postFileStream(path: String, authToken: String?, filePath: String, randomId: String): String
     fun getFileStream(path: String, authToken: String?, params: Map<String, String>): InputStream
 
     enum class AuthScheme { basic, jwt }
@@ -77,10 +77,12 @@ interface HttpClient {
                     .build()
         }
 
-        private fun postStream(url: String, authToken: String?, filePath: String): Request {
+        private fun postStream(url: String, authToken: String?, filePath: String,
+                               randomId: String): Request {
             val body = StreamRequest(MEDIA_TYPE_PLAINTEXT, filePath)
             return Request.Builder()
                     .addAuthorizationHeader(authToken)
+                    .addHeader("random-id", randomId)
                     .url(url)
                     .post(body)
                     .build()
@@ -212,9 +214,9 @@ interface HttpClient {
             return ApiCall.executeFileRequest(client, request)
         }
 
-        override fun postFileStream(path: String, authToken: String?, filePath: String): String {
+        override fun postFileStream(path: String, authToken: String?, filePath: String, randomId: String): String {
             val request = postStream(url = baseUrl + path, authToken = authToken,
-                    filePath = filePath)
+                    filePath = filePath, randomId = randomId)
             return ApiCall.executeRequest(client, request)
         }
 

--- a/src/main/kotlin/com/criptext/mail/db/dao/EmailContactDao.kt
+++ b/src/main/kotlin/com/criptext/mail/db/dao/EmailContactDao.kt
@@ -39,12 +39,8 @@ interface EmailContactJoinDao {
     fun getAll() : List<EmailContact>
 
     @Query("""SELECT * FROM email_contact
-        LEFT JOIN email ON email.id= email_contact.emailId
-        WHERE delivered NOT IN (1,4)
-        AND email_contact.emailId NOT IN
-        (SELECT email_label.emailId FROM email_label WHERE email_label.emailId = email_contact.emailId and email_label.labelId=6)
-    """)
-    fun getAllForLinkFile() : List<EmailContact>
+        WHERE emailId in (:emailIds)""")
+    fun getAllForLinkFile(emailIds: List<Long>) : List<EmailContact>
 
     @Insert
     fun insert(emailContact : EmailContact)

--- a/src/main/kotlin/com/criptext/mail/db/dao/EmailLabelDao.kt
+++ b/src/main/kotlin/com/criptext/mail/db/dao/EmailLabelDao.kt
@@ -39,12 +39,8 @@ interface EmailLabelDao {
     fun getAll() : List<EmailLabel>
 
     @Query("""SELECT * FROM email_label
-        left join email on email_label.emailId=email.id
-        where delivered not in (1, 4)
-        AND NOT EXISTS
-        (SELECT * FROM email_label WHERE email_label.emailId = email.id and email_label.labelId=6)
-    """)
-    fun getAllForLinkFile() : List<EmailLabel>
+        where emailId in (:emailIds)""")
+    fun getAllForLinkFile(emailIds: List<Long>) : List<EmailLabel>
 
     @Delete
     fun deleteAll(emailLabels: List<EmailLabel>)

--- a/src/main/kotlin/com/criptext/mail/db/dao/FileDao.kt
+++ b/src/main/kotlin/com/criptext/mail/db/dao/FileDao.kt
@@ -38,6 +38,10 @@ interface FileDao {
             WHERE file.emailId=:emailId""")
     fun getAttachmentsFromEmail(emailId: Long) : List<CRFile>
 
+    @Query("""SELECT * FROM file
+            WHERE file.emailId in (:emailId)""")
+    fun getAttachmentsFromEmails(emailId: List<Long>) : List<CRFile>
+
     @Query("""UPDATE file
             SET status=:status
             WHERE file.emailId=:emailId""")

--- a/src/main/kotlin/com/criptext/mail/db/dao/FileKeyDao.kt
+++ b/src/main/kotlin/com/criptext/mail/db/dao/FileKeyDao.kt
@@ -33,6 +33,10 @@ interface FileKeyDao {
             WHERE file_key.emailId=:emailId""")
     fun getAttachmentKeyFromEmail(emailId: Long) : FileKey?
 
+    @Query("""SELECT * FROM file_key
+            WHERE file_key.emailId in (:emailIds)""")
+    fun getAttachmentKeyFromEmails(emailIds: List<Long>) : List<FileKey>
+
     @Delete
     fun deleteAll(files: List<FileKey>)
 

--- a/src/main/kotlin/com/criptext/mail/db/models/Contact.kt
+++ b/src/main/kotlin/com/criptext/mail/db/models/Contact.kt
@@ -61,7 +61,7 @@ open class Contact(
             val json = JSONObject(jsonString)
             val id = json.getLong("id")
             val email = json.getString("email")
-            val name = json.getString("name")
+            val name = if(json.has("name")) json.getString("name") else ""
             return Contact(
                     id =  id,
                     email = email,

--- a/src/main/kotlin/com/criptext/mail/db/models/Email.kt
+++ b/src/main/kotlin/com/criptext/mail/db/models/Email.kt
@@ -73,12 +73,12 @@ data class Email(
                         unread = json.getBoolean("unread"),
                         secure = json.getBoolean("secure"),
                         content = json.getString("content"),
-                        preview = json.getString("preview"),
-                        subject = json.getString("subject"),
-                        delivered = DeliveryTypes.fromInt(json.getInt("delivered")),
+                        preview = if(json.has("preview")) json.getString("preview") else "",
+                        subject = if(json.has("subject")) json.getString("subject") else "",
+                        delivered = DeliveryTypes.fromInt(json.getInt("status")),
                         date = com.criptext.mail.utils.DateUtils.getDateFromString(
                                 json.getString("date"), null),
-                        metadataKey = json.getLong("metadataKey"),
+                        metadataKey = json.getLong("key"),
                         isMuted = json.getBoolean("isMuted"),
                         unsentDate = if(json.has("unsentDate")) com.criptext.mail.utils.DateUtils.getDateFromString(
                                 json.getString("unsentDate"), null) else null,

--- a/src/main/kotlin/com/criptext/mail/db/models/FileKey.kt
+++ b/src/main/kotlin/com/criptext/mail/db/models/FileKey.kt
@@ -37,7 +37,9 @@ class FileKey(
             val json = JSONObject(jsonString)
             return FileKey(
                     id = json.getLong("id"),
-                    key = if(json.has("key")) json.getString("key") else null,
+                    key = if(json.has("key"))
+                        json.getString("key").plus(":".plus(json.getString("iv")))
+                    else null,
                     emailId = json.getLong("emailId")
             )
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerController.kt
@@ -267,7 +267,8 @@ class ComposerController(private val model: ComposerModel,
     private fun onLinkAccept(resultData: GeneralResult.LinkAccept){
         when (resultData) {
             is GeneralResult.LinkAccept.Success -> {
-                host.exitToScene(LinkingParams(activeAccount.userEmail), null,
+                host.exitToScene(LinkingParams(activeAccount.userEmail, resultData.deviceId,
+                        resultData.uuid), null,
                         false, true)
             }
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailSceneController.kt
@@ -624,7 +624,7 @@ class EmailDetailSceneController(private val scene: EmailDetailScene,
     }
 
     private val webSocketEventListener = object : WebSocketEventListener {
-        override fun onDeviceDataUploaded(key: String, dataAddress: String) {
+        override fun onDeviceDataUploaded(key: String, dataAddress: String, authorizerId: Int) {
 
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/LinkingActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/LinkingActivity.kt
@@ -10,6 +10,7 @@ import com.criptext.mail.db.EventLocalDB
 import com.criptext.mail.db.KeyValueStorage
 import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.scenes.SceneController
+import com.criptext.mail.scenes.linking.data.LinkingDataSource
 import com.criptext.mail.scenes.settings.recovery_email.data.RecoveryEmailDataSource
 import com.criptext.mail.signal.SignalClient
 import com.criptext.mail.signal.SignalStoreCriptext
@@ -32,7 +33,7 @@ class LinkingActivity: BaseActivity(){
         val webSocketEvents = WebSocketSingleton.getInstance(
                 activeAccount = activeAccount!!)
 
-        val dataSource = RecoveryEmailDataSource(
+        val dataSource = LinkingDataSource(
                 httpClient = HttpClient.Default(),
                 activeAccount = activeAccount!!,
                 runner = AsyncTaskWorkRunner(),

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/LinkingModel.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/LinkingModel.kt
@@ -1,9 +1,11 @@
 package com.criptext.mail.scenes.linking
 
-class LinkingModel(val email: String) {
+import com.criptext.mail.signal.PreKeyBundleShareData
+
+class LinkingModel(val email: String, var remoteDeviceId: Int, val randomId: String) {
     var untrustedDevicePostedKeyBundle: Boolean = false
-    var remoteDeviceId: Int = 0
     var dataFileHasBeenCreated = false
     var dataFilePath = ""
     var dataFileKey: ByteArray? = null
+    var keyBundle: PreKeyBundleShareData.DownloadBundle? = null
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/data/CheckForKeyBundleAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/data/CheckForKeyBundleAPIClient.kt
@@ -1,0 +1,12 @@
+package com.criptext.mail.scenes.linking.data
+
+import com.criptext.mail.api.HttpClient
+import org.json.JSONObject
+
+
+class CheckForKeyBundleAPIClient(private val httpClient: HttpClient, private val token: String) {
+
+    fun getKeyBundle(deviceId: Int): String{
+        return httpClient.get(path = "/keybundle/$deviceId", authToken = token)
+    }
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/data/CheckForKeyBundleWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/data/CheckForKeyBundleWorker.kt
@@ -1,0 +1,53 @@
+package com.criptext.mail.scenes.linking.data
+
+import com.criptext.mail.R
+import com.criptext.mail.api.HttpClient
+import com.criptext.mail.api.HttpErrorHandlingHelper
+import com.criptext.mail.bgworker.BackgroundWorker
+import com.criptext.mail.bgworker.ProgressReporter
+import com.criptext.mail.db.models.ActiveAccount
+import com.criptext.mail.signal.PreKeyBundleShareData
+import com.criptext.mail.utils.UIMessage
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.flatMap
+import com.github.kittinunf.result.mapError
+import org.json.JSONObject
+
+
+class CheckForKeyBundleWorker(
+        private val deviceId: Int,
+        httpClient: HttpClient,
+        private val activeAccount: ActiveAccount,
+        override val publishFn: (
+                LinkingResult.CheckForKeyBundle) -> Unit)
+    : BackgroundWorker<LinkingResult.CheckForKeyBundle> {
+
+    override val canBeParallelized = true
+    private val apiClient = CheckForKeyBundleAPIClient(httpClient, activeAccount.jwt)
+
+    override fun catchException(ex: Exception): LinkingResult.CheckForKeyBundle {
+        return LinkingResult.CheckForKeyBundle.Failure(UIMessage(R.string.password_enter_error))
+    }
+
+    override fun work(reporter: ProgressReporter<LinkingResult.CheckForKeyBundle>): LinkingResult.CheckForKeyBundle? {
+        val operation =
+                Result.of {
+                    apiClient.getKeyBundle(deviceId)
+                }
+                .mapError(HttpErrorHandlingHelper.httpExceptionsToNetworkExceptions)
+                .flatMap { Result.of { PreKeyBundleShareData.DownloadBundle.fromJSON(JSONObject(it)) } }
+        return when (operation){
+            is Result.Success -> {
+                LinkingResult.CheckForKeyBundle.Success(operation.value)
+            }
+            is Result.Failure -> {
+                catchException(operation.error)
+            }
+        }
+    }
+
+    override fun cancel() {
+        TODO("CANCEL IS NOT IMPLEMENTED")
+    }
+
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/data/LinkingDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/data/LinkingDataSource.kt
@@ -1,0 +1,31 @@
+package com.criptext.mail.scenes.linking.data
+
+import com.criptext.mail.api.HttpClient
+import com.criptext.mail.bgworker.BackgroundWorkManager
+import com.criptext.mail.bgworker.BackgroundWorker
+import com.criptext.mail.bgworker.WorkRunner
+import com.criptext.mail.db.KeyValueStorage
+import com.criptext.mail.db.SettingsLocalDB
+import com.criptext.mail.db.models.ActiveAccount
+
+class LinkingDataSource(
+        private val storage: KeyValueStorage,
+        private val activeAccount: ActiveAccount,
+        private val httpClient: HttpClient,
+        override val runner: WorkRunner)
+    : BackgroundWorkManager<LinkingRequest, LinkingResult>(){
+
+    override fun createWorkerFromParams(params: LinkingRequest,
+                                        flushResults: (LinkingResult) -> Unit): BackgroundWorker<*> {
+
+        return when(params){
+            is LinkingRequest.CheckForKeyBundle -> CheckForKeyBundleWorker(
+                    deviceId = params.deviceId,
+                    activeAccount = activeAccount,
+                    httpClient = httpClient,
+                    publishFn = { result ->
+                        flushResults(result) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/data/LinkingRequest.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/data/LinkingRequest.kt
@@ -1,0 +1,5 @@
+package com.criptext.mail.scenes.linking.data
+
+sealed class LinkingRequest{
+    data class CheckForKeyBundle(val deviceId: Int): LinkingRequest()
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/linking/data/LinkingResult.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/linking/data/LinkingResult.kt
@@ -1,0 +1,11 @@
+package com.criptext.mail.scenes.linking.data
+
+import com.criptext.mail.signal.PreKeyBundleShareData
+import com.criptext.mail.utils.UIMessage
+
+sealed class LinkingResult{
+    sealed class CheckForKeyBundle: LinkingResult() {
+        data class Success(val keyBundle: PreKeyBundleShareData.DownloadBundle): CheckForKeyBundle()
+        data class Failure(val message: UIMessage): CheckForKeyBundle()
+    }
+}

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxSceneController.kt
@@ -705,7 +705,8 @@ class MailboxSceneController(private val scene: MailboxScene,
     private fun onLinkAccept(resultData: GeneralResult.LinkAccept){
         when (resultData) {
             is GeneralResult.LinkAccept.Success -> {
-                host.exitToScene(LinkingParams(activeAccount.userEmail), null,
+                host.exitToScene(LinkingParams(activeAccount.userEmail, resultData.deviceId,
+                        resultData.uuid), null,
                         false, true)
             }
             is GeneralResult.LinkAccept.Failure -> {
@@ -754,7 +755,7 @@ class MailboxSceneController(private val scene: MailboxScene,
     }
 
     private val webSocketEventListener = object : WebSocketEventListener {
-        override fun onDeviceDataUploaded(key: String, dataAddress: String) {
+        override fun onDeviceDataUploaded(key: String, dataAddress: String, authorizerId: Int) {
 
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/params/LinkingParams.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/params/LinkingParams.kt
@@ -2,7 +2,7 @@ package com.criptext.mail.scenes.params
 
 import com.criptext.mail.scenes.linking.LinkingActivity
 
-open class LinkingParams(val email: String): SceneParams() {
+open class LinkingParams(val email: String, val deviceId: Int, val randomId: String): SceneParams() {
     override val activityClass = LinkingActivity::class.java
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
@@ -345,7 +345,7 @@ class SettingsController(
     }
 
     private val webSocketEventListener = object : WebSocketEventListener {
-        override fun onDeviceDataUploaded(key: String, dataAddress: String) {
+        override fun onDeviceDataUploaded(key: String, dataAddress: String, authorizerId: Int) {
 
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/changepassword/ChangePasswordController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/changepassword/ChangePasswordController.kt
@@ -197,7 +197,7 @@ class ChangePasswordController(
     }
 
     private val webSocketEventListener = object : WebSocketEventListener {
-        override fun onDeviceDataUploaded(key: String, dataAddress: String) {
+        override fun onDeviceDataUploaded(key: String, dataAddress: String, authorizerId: Int) {
 
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/devices/DeviceItem.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/devices/DeviceItem.kt
@@ -1,6 +1,5 @@
 package com.criptext.mail.scenes.settings.devices
 
-import com.criptext.mail.utils.DeviceUtils
 import org.json.JSONArray
 
 data class DeviceItem(val id: Int, val deviceType: Int, val friendlyName: String, val name: String, val isCurrent: Boolean) {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/recovery_email/RecoveryEmailController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/recovery_email/RecoveryEmailController.kt
@@ -217,7 +217,7 @@ class RecoveryEmailController(
     }
 
     private val webSocketEventListener = object : WebSocketEventListener {
-        override fun onDeviceDataUploaded(key: String, dataAddress: String) {
+        override fun onDeviceDataUploaded(key: String, dataAddress: String, authorizerId: Int) {
 
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/SignInScene.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/SignInScene.kt
@@ -26,7 +26,7 @@ interface SignInScene {
             onPasswordLoginDialogListener: OnPasswordLoginDialogListener)
     fun setSubmitButtonState(state: ProgressButtonState)
     fun showKeyGenerationHolder()
-    fun showLinkBeginError()
+    fun showLinkAuthError()
     fun showLinkDeviceProcessAnimation()
     fun toggleForgotPasswordClickable(isEnabled: Boolean)
     fun toggleResendClickable(isEnabled: Boolean)
@@ -129,7 +129,7 @@ interface SignInScene {
             }
         }
 
-        override fun showLinkBeginError() {
+        override fun showLinkAuthError() {
             val currentHolder = holder
             when (currentHolder) {
                 is LoginValidationHolder -> currentHolder.showFailedLogin()

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/LinkAuthWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/LinkAuthWorker.kt
@@ -4,7 +4,9 @@ import com.criptext.mail.R
 import com.criptext.mail.api.HttpClient
 import com.criptext.mail.bgworker.BackgroundWorker
 import com.criptext.mail.bgworker.ProgressReporter
+import com.criptext.mail.scenes.settings.devices.DeviceItem
 import com.criptext.mail.scenes.signup.data.SignUpAPIClient
+import com.criptext.mail.utils.DeviceUtils
 import com.criptext.mail.utils.UIMessage
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
@@ -16,7 +18,7 @@ class LinkAuthWorker(val httpClient: HttpClient,
                      override val publishFn: (SignInResult) -> Unit)
     : BackgroundWorker<SignInResult.LinkAuth> {
 
-    private val apiClient = SignUpAPIClient(httpClient)
+    private val apiClient = SignInAPIClient(httpClient)
 
     override val canBeParallelized = false
 
@@ -25,7 +27,11 @@ class LinkAuthWorker(val httpClient: HttpClient,
     }
 
     override fun work(reporter: ProgressReporter<SignInResult.LinkAuth>): SignInResult.LinkAuth? {
-        val result =  Result.of { apiClient.postLinkAuth(username, jwt) }
+
+        val device = DeviceItem(0, DeviceUtils.getDeviceType().ordinal,
+                DeviceUtils.getDeviceFriendlyName(), DeviceUtils.getDeviceName(), true)
+
+        val result =  Result.of { apiClient.postLinkAuth(username, jwt, device) }
 
         return when (result) {
             is Result.Success ->{

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/LinkDataWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/LinkDataWorker.kt
@@ -30,7 +30,8 @@ import java.io.OutputStream
 
 
 
-class LinkDataWorker(val activeAccount: ActiveAccount,
+class LinkDataWorker(private val authorizerId: Int,
+                     val activeAccount: ActiveAccount,
                      private val key: String,
                      private val dataAddress: String,
                      private val signalClient: SignalClient,
@@ -72,7 +73,7 @@ class LinkDataWorker(val activeAccount: ActiveAccount,
         val result =  Result.of { apiClient.getFileStream(activeAccount.jwt, params) }
                 .flatMap { readIntoFile(it) }
                 .flatMap { Result.of { Pair(signalClient.decryptBytes(activeAccount.recipientId,
-                        activeAccount.deviceId,
+                        authorizerId,
                         SignalEncryptedData(key, SignalEncryptedData.Type.preKey)),
                         it
                 )

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/LinkDeviceState.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/LinkDeviceState.kt
@@ -4,5 +4,6 @@ sealed class LinkDeviceState {
     class Begin: LinkDeviceState()
     class Auth: LinkDeviceState()
     class Accepted: LinkDeviceState()
+    class Denied: LinkDeviceState()
     class WaitingForDownload: LinkDeviceState()
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInAPIClient.kt
@@ -1,7 +1,10 @@
 package com.criptext.mail.scenes.signin.data
 
 import com.criptext.mail.api.HttpClient
+import com.criptext.mail.scenes.settings.devices.DeviceItem
 import com.criptext.mail.signal.PreKeyBundleShareData
+import com.criptext.mail.utils.DeviceUtils
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.InputStream
 
@@ -34,6 +37,38 @@ class SignInAPIClient(private val httpClient: HttpClient) {
 
     fun getFileStream(token: String, params: Map<String,String>): InputStream {
         return httpClient.getFileStream(path = "/userdata", authToken = token, params = params)
+    }
+
+    fun postLinkBegin(recipientId: String): String{
+        val jsonPut = JSONObject()
+        jsonPut.put("targetUsername", recipientId)
+
+        return httpClient.post(path = "/link/begin", authToken = null, body = jsonPut)
+    }
+
+    fun getLinkStatus(jwt: String): String{
+        return httpClient.get(path = "/link/status", authToken = jwt)
+    }
+
+    fun postLinkAuth(recipientId: String, jwt: String, device: DeviceItem): String{
+        val jsonPut = JSONObject()
+        jsonPut.put("recipientId", recipientId)
+        jsonPut.put("deviceName", device.name)
+        jsonPut.put("deviceFriendlyName", device.friendlyName)
+        jsonPut.put("deviceType", device.deviceType)
+
+        return httpClient.post(path = "/link/auth", authToken = jwt, body = jsonPut)
+    }
+
+    fun isLinkDataReady(token: String): String {
+        return httpClient.get("/link/data/ready", authToken = token)
+    }
+
+    fun acknowledgeEvents(eventIds: List<Long>, token: String): String {
+        val jsonObject = JSONObject()
+        jsonObject.put("ids", JSONArray(eventIds))
+
+        return httpClient.post(authToken = token, path = "/event/ack", body = jsonObject)
     }
 
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInDataSource.kt
@@ -93,10 +93,18 @@ class SignInDataSource(override val runner: WorkRunner,
 
             is SignInRequest.LinkData -> LinkDataWorker(
                     activeAccount = ActiveAccount.loadFromStorage(keyValueStorage)!!,
+                    authorizerId = params.authorizerId,
                     dataAddress = params.dataAddress,
                     key = params.key,
                     signalClient = SignalClient.Default(SignalStoreCriptext(db)),
                     db = db,
+                    publishFn = {
+                        result -> flushResults(result)
+                    }
+            )
+            is SignInRequest.LinkDataReady -> LinkDataReadyWorker(
+                    activeAccount = ActiveAccount.loadFromStorage(keyValueStorage)!!,
+                    httpClient = httpClient,
                     publishFn = {
                         result -> flushResults(result)
                     }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInRequest.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInRequest.kt
@@ -22,7 +22,9 @@ sealed class SignInRequest{
 
     data class CreateSessionFromLink(val name: String, val username: String, val randomId: Int,
                                      val ephemeralJwt: String): SignInRequest()
-    data class LinkData(val key: String, val dataAddress: String): SignInRequest()
+    data class LinkData(val key: String, val dataAddress: String, val authorizerId: Int): SignInRequest()
 
     data class LinkStatus(val ephemeralJwt: String): SignInRequest()
+
+    class LinkDataReady: SignInRequest()
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInResult.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/data/SignInResult.kt
@@ -59,8 +59,14 @@ sealed class SignInResult {
     }
 
     sealed class LinkStatus: SignInResult() {
-        class Success: LinkStatus()
+        data class Success(val name: String, val deviceId: Int): LinkStatus()
         class Waiting: LinkStatus()
         class Denied: LinkStatus()
+    }
+
+    sealed class LinkDataReady: SignInResult() {
+        data class Success(val key: String, val dataAddress: String, val authorizerId: Int): LinkDataReady()
+        data class Failure(val message: UIMessage,
+                           val exception: Exception): LinkDataReady()
     }
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/signup/data/SignUpAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signup/data/SignUpAPIClient.kt
@@ -4,6 +4,7 @@ import com.criptext.mail.api.HttpClient
 import com.criptext.mail.signal.PreKeyBundleShareData
 import com.criptext.mail.scenes.signup.IncompleteAccount
 import com.criptext.mail.utils.DeviceUtils
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -43,26 +44,5 @@ class SignUpAPIClient(private val httpClient: HttpClient) {
         jsonPut.put("devicePushToken", pushToken)
 
         return httpClient.put(path = "/keybundle/pushtoken", authToken = jwt, body = jsonPut)
-    }
-
-    fun postLinkBegin(recipientId: String): String{
-        val jsonPut = JSONObject()
-        jsonPut.put("targetUsername", recipientId)
-
-        return httpClient.post(path = "/link/begin", authToken = null, body = jsonPut)
-    }
-
-    fun postLinkStatus(jwt: String): String{
-        return httpClient.post(path = "/link/status", authToken = jwt, body = JSONObject())
-    }
-
-    fun postLinkAuth(recipientId: String, jwt: String): String{
-        val jsonPut = JSONObject()
-        jsonPut.put("recipientId", recipientId)
-        jsonPut.put("deviceName", DeviceUtils.getDeviceName())
-        jsonPut.put("deviceFriendlyName", DeviceUtils.getDeviceFriendlyName())
-        jsonPut.put("deviceType", DeviceUtils.getDeviceType().ordinal)
-
-        return httpClient.post(path = "/link/auth", authToken = jwt, body = jsonPut)
     }
 }

--- a/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralAPIClient.kt
@@ -49,23 +49,20 @@ class GeneralAPIClient(private val httpClient: HttpClient, private val token: St
         return httpClient.post(path = "/link/deny", authToken = token, body = jsonPost)
     }
 
-    fun postFileStream(filePath: String): String {
-        return httpClient.postFileStream(path = "/userdata", authToken = token, filePath = filePath)
+    fun postFileStream(filePath: String, randomId: String): String {
+        return httpClient.postFileStream(path = "/userdata", authToken = token, filePath = filePath,
+                randomId = randomId)
     }
 
-    fun postLinkDataAddress(deviceId: Int, dataAddress: String, key: String): String {
+    fun postLinkDataReady(deviceId: Int, key: String): String {
         val jsonPost = JSONObject()
         jsonPost.put("deviceId", deviceId)
-        jsonPost.put("dataAddress", dataAddress)
         jsonPost.put("key", key)
-        return httpClient.post(path = "/link/dataaddress", authToken = token, body = jsonPost)
+        return httpClient.post(path = "/link/data/ready", authToken = token, body = jsonPost)
     }
 
-    fun findKeyBundles(recipients: List<String>, knownAddresses: Map<String, List<Int>>): String {
-        val jsonObject = JSONObject()
-        jsonObject.put("recipients", JSONArray(recipients))
-        jsonObject.put("knownAddresses", JSONObject(knownAddresses))
-        return httpClient.post(path = "/keybundle/find", authToken = token, body = jsonObject)
+    fun getKeyBundle(deviceId: Int): String{
+        return httpClient.get(path = "/keybundle/$deviceId", authToken = token)
     }
 
 }

--- a/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralDataSource.kt
@@ -9,7 +9,6 @@ import com.criptext.mail.db.EventLocalDB
 import com.criptext.mail.db.KeyValueStorage
 import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.signal.SignalClient
-import com.criptext.mail.signal.SignalStoreCriptext
 import com.criptext.mail.utils.generaldatasource.workers.*
 
 class GeneralDataSource(override val runner: WorkRunner,
@@ -63,9 +62,11 @@ class GeneralDataSource(override val runner: WorkRunner,
             is GeneralRequest.PostUserData -> PostUserWorker(
                     httpClient = httpClient,
                     activeAccount = activeAccount!!,
+                    randomId = params.randomId,
                     filePath = params.filePath,
                     deviceId = params.deviceID,
                     fileKey = params.key,
+                    keyBundle = params.keyBundle,
                     signalClient = signalClient,
                     publishFn = { res -> flushResults(res)}
             )

--- a/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralRequest.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralRequest.kt
@@ -2,6 +2,7 @@ package com.criptext.mail.utils.generaldatasource.data
 
 import com.criptext.mail.api.models.UntrustedDeviceInfo
 import com.criptext.mail.db.models.Label
+import com.criptext.mail.signal.PreKeyBundleShareData
 
 sealed class GeneralRequest {
     data class DeviceRemoved(val letAPIKnow: Boolean): GeneralRequest()
@@ -13,5 +14,7 @@ sealed class GeneralRequest {
     data class LinkAccept(val untrustedDeviceInfo: UntrustedDeviceInfo): GeneralRequest()
     data class LinkDenied(val untrustedDeviceInfo: UntrustedDeviceInfo): GeneralRequest()
     class DataFileCreation: GeneralRequest()
-    data class PostUserData(val deviceID: Int, val filePath: String, val key: ByteArray): GeneralRequest()
+    data class PostUserData(val deviceID: Int, val filePath: String, val key: ByteArray,
+                            val randomId: String,
+                            val keyBundle: PreKeyBundleShareData.DownloadBundle?): GeneralRequest()
 }

--- a/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralResult.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/generaldatasource/data/GeneralResult.kt
@@ -4,6 +4,7 @@ package com.criptext.mail.utils.generaldatasource.data
 import com.criptext.mail.db.models.Label
 import com.criptext.mail.email_preview.EmailPreview
 import com.criptext.mail.utils.UIMessage
+import java.util.*
 
 /**
  * Created by gabriel on 5/1/18.
@@ -65,7 +66,7 @@ sealed class GeneralResult {
     }
 
     sealed class LinkAccept: GeneralResult() {
-        class Success: LinkAccept()
+        data class Success(val deviceId: Int, val uuid: String): LinkAccept()
         data class Failure(val message: UIMessage): LinkAccept()
     }
 

--- a/src/main/kotlin/com/criptext/mail/utils/generaldatasource/workers/LinkAuthAcceptWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/generaldatasource/workers/LinkAuthAcceptWorker.kt
@@ -9,8 +9,8 @@ import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.utils.UIMessage
 import com.criptext.mail.utils.generaldatasource.data.GeneralAPIClient
 import com.criptext.mail.utils.generaldatasource.data.GeneralResult
-import com.criptext.mail.utils.sha256
 import com.github.kittinunf.result.Result
+import org.json.JSONObject
 
 class LinkAuthAcceptWorker(private val untrustedDeviceInfo: UntrustedDeviceInfo,
                            private val activeAccount: ActiveAccount,
@@ -32,12 +32,12 @@ class LinkAuthAcceptWorker(private val untrustedDeviceInfo: UntrustedDeviceInfo,
             return GeneralResult.LinkAccept.Failure(UIMessage(R.string.server_error_exception))
 
         val operation = Result.of {
-            apiClient.postLinkAccept(untrustedDeviceInfo.deviceId)
+            JSONObject(apiClient.postLinkAccept(untrustedDeviceInfo.deviceId)).getInt("deviceId")
         }
 
         return when (operation){
             is Result.Success -> {
-                GeneralResult.LinkAccept.Success()
+                GeneralResult.LinkAccept.Success(operation.value, untrustedDeviceInfo.deviceId)
             }
             is Result.Failure -> {
                 GeneralResult.LinkAccept.Failure(UIMessage(R.string.server_error_exception))

--- a/src/main/kotlin/com/criptext/mail/websocket/WebSocketController.kt
+++ b/src/main/kotlin/com/criptext/mail/websocket/WebSocketController.kt
@@ -54,7 +54,8 @@ class WebSocketController(private val wsClient: WebSocketClient, jwt: String): W
             Event.Cmd.deviceDataUploadComplete -> {
                 val dataAddress = JSONObject(event.params).getString("dataAddress")
                 val key = JSONObject(event.params).getString("key")
-                currentListener?.onDeviceDataUploaded(key, dataAddress)
+                val authorizerId = JSONObject(event.params).getInt("authorizerId")
+                currentListener?.onDeviceDataUploaded(key, dataAddress, authorizerId)
             }
 
             else -> currentListener?.onError(UIMessage(R.string.web_socket_error,

--- a/src/main/kotlin/com/criptext/mail/websocket/WebSocketEventListener.kt
+++ b/src/main/kotlin/com/criptext/mail/websocket/WebSocketEventListener.kt
@@ -63,7 +63,7 @@ interface WebSocketEventListener {
      * Invoked when the recovery email has been confirmed. Subscribers should try to
      * add the update to the list of notifications in the UI.
      */
-    fun onDeviceDataUploaded(key: String, dataAddress: String)
+    fun onDeviceDataUploaded(key: String, dataAddress: String, authorizerId: Int)
 
     /**
      * Invoked when the recovery email has been confirmed. Subscribers should try to

--- a/src/main/res/layout/link_device_auth_dialog.xml
+++ b/src/main/res/layout/link_device_auth_dialog.xml
@@ -42,7 +42,7 @@
             android:layout_weight="0.5"
             android:background="@drawable/label_button_left_bg"
             android:stateListAnimator="@null"
-            android:text="@string/no"
+            android:text="@string/push_deny"
             android:textAllCaps="false"
             android:textColor="@color/label_buttons_text"
             android:textSize="15sp" />
@@ -58,7 +58,7 @@
             android:layout_width="0dp"
             android:layout_weight="0.5"
             android:layout_height="wrap_content"
-            android:text="@string/yes"/>
+            android:text="@string/push_approve"/>
 
     </LinearLayout>
 </LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
 
     <!-- DEVICE AUTHENTICATION -->
     <string name="push_approve">Approve</string>
-    <string name="push_deny">Deny</string>
+    <string name="push_deny">Reject</string>
     <string name="push_link_error_title">Device Authentication</string>
     <string name="push_link_error_message_approve">Error on approving device, resend authentication request.</string>
     <string name="push_link_error_message_deny">Error on denying device. Check your internet connection.</string>


### PR DESCRIPTION
Now there are retries for all link devices events, and the output file is now following the standard for all clients. Also fixed an issue with some repeated id's in the output file. 