### PR TITLE
Notifications now act faster on action buttons and Mailbox Update issue.

### DIFF
--- a/src/androidTest/kotlin/com/criptext/mail/scenes/emaildetail/data/DownloadAttachmentWorkerTest.kt
+++ b/src/androidTest/kotlin/com/criptext/mail/scenes/emaildetail/data/DownloadAttachmentWorkerTest.kt
@@ -1,6 +1,8 @@
 package com.criptext.mail.scenes.emaildetail.data
 
+import android.Manifest
 import android.support.test.rule.ActivityTestRule
+import android.support.test.rule.GrantPermissionRule
 import android.support.test.runner.AndroidJUnit4
 import com.criptext.mail.Config
 import com.criptext.mail.androidtest.TestActivity
@@ -11,8 +13,9 @@ import com.criptext.mail.db.models.ActiveAccount
 import com.criptext.mail.scenes.composer.data.ComposerResult
 import com.criptext.mail.scenes.composer.data.UploadAttachmentWorker
 import com.criptext.mail.scenes.emaildetail.workers.DownloadAttachmentWorker
-import com.criptext.mail.utils.Encoding
-import com.criptext.mail.utils.*
+import com.criptext.mail.utils.FileDownloader
+import com.criptext.mail.utils.MockedResponse
+import com.criptext.mail.utils.enqueueResponses
 import com.criptext.mail.utils.file.AndroidFs
 import io.mockk.mockk
 import okhttp3.mockwebserver.MockWebServer
@@ -25,13 +28,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
-import java.nio.charset.Charset
+
 
 @RunWith(AndroidJUnit4::class)
 class DownloadAttachmentWorkerTest {
 
     @get:Rule
     val mActivityRule = ActivityTestRule(TestActivity::class.java)
+    @get:Rule
+    var mRuntimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
     private lateinit var db: TestDatabase
     private lateinit var mockWebServer: MockWebServer

--- a/src/androidTest/kotlin/com/criptext/mail/scenes/mailbox/data/UpdateEmailThreadsLabelsWorkerTest.kt
+++ b/src/androidTest/kotlin/com/criptext/mail/scenes/mailbox/data/UpdateEmailThreadsLabelsWorkerTest.kt
@@ -84,7 +84,7 @@ class UpdateEmailThreadsLabelsWorkerTest {
                 ExpectedRequest(
                         expectedAuthScheme = ExpectedAuthScheme.Jwt(activeAccount.jwt),
                         method = "POST", path = "/event/peers",
-                        assertBodyFn = {it shouldEqual "{\"peerEvents\":[\"{\"cmd\":304,\"params\":{\"threadIds\":[\"${selectedThread[0]}\"],\"labelsRemoved\":[],\"labelsAdded\":[\"Starred\"]}}\"]}"})
+                        assertBodyFn = {it shouldEqual """{"peerEvents":["{\"cmd\":304,\"params\":{\"threadIds\":[\"${selectedThread[0]}\"],\"labelsRemoved\":[],\"labelsAdded\":[\"Starred\"]}}"]}"""})
         ))
 
     }

--- a/src/main/kotlin/com/criptext/mail/push/data/PushAPIRequestHandler.kt
+++ b/src/main/kotlin/com/criptext/mail/push/data/PushAPIRequestHandler.kt
@@ -81,6 +81,7 @@ class PushAPIRequestHandler(private val not: CriptextNotification,
     }
 
     fun openEmail(metadataKey: Long, notificationId: Int, emailDao: EmailDao, pendingDao: PendingEventDao){
+        handleNotificationCountForNewEmail(notificationId)
         val peerEventsApiHandler = PeerEventsApiHandler.Default(httpClient, activeAccount.jwt, pendingDao)
         val operation = Result.of {
             val email = emailDao.getEmailByMetadataKey(metadataKey)
@@ -95,10 +96,8 @@ class PushAPIRequestHandler(private val not: CriptextNotification,
 
         when(operation){
             is Result.Success -> {
-                handleNotificationCountForNewEmail(notificationId)
             }
             is Result.Failure -> {
-                handleNotificationCountForNewEmail(notificationId)
                 operation.error.printStackTrace()
                 val data = PushData.Error(UIMessage(R.string.push_email_error_title),
                         UIMessage(R.string.push_mail_error_message_read), isPostNougat, true)
@@ -110,6 +109,7 @@ class PushAPIRequestHandler(private val not: CriptextNotification,
     }
 
     fun trashEmail(metadataKey: Long, notificationId: Int, db: EmailDetailLocalDB, emailDao: EmailDao, pendingDao: PendingEventDao){
+        handleNotificationCountForNewEmail(notificationId)
         val peerEventsApiHandler = PeerEventsApiHandler.Default(httpClient, activeAccount.jwt, pendingDao)
         val chosenLabel = Label.LABEL_TRASH
         val currentLabel = Label.defaultItems.inbox
@@ -146,10 +146,9 @@ class PushAPIRequestHandler(private val not: CriptextNotification,
 
         return when (result) {
             is Result.Success -> {
-                handleNotificationCountForNewEmail(notificationId)
+
             }
             is Result.Failure -> {
-                handleNotificationCountForNewEmail(notificationId)
                 val data = PushData.Error(UIMessage(R.string.push_email_error_title),
                         UIMessage(R.string.push_mail_error_message_trash), isPostNougat, true)
                 val errorNot = not.createNotification(CriptextNotification.ERROR_ID,

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/MailboxSceneController.kt
@@ -352,7 +352,7 @@ class MailboxSceneController(private val scene: MailboxScene,
         }
 
         dataSource.submitRequest(MailboxRequest.GetMenuInformation())
-        reloadMailboxThreads()
+        if (model.threads.isEmpty()) reloadMailboxThreads()
 
         toggleMultiModeBar()
         scene.setToolbarNumberOfEmails(getTotalUnreadThreads())

--- a/src/test/java/com/criptext/mail/scenes/mailbox/MailboxControllerLifecycleTest.kt
+++ b/src/test/java/com/criptext/mail/scenes/mailbox/MailboxControllerLifecycleTest.kt
@@ -69,7 +69,9 @@ class MailboxControllerLifecycleTest: MailboxControllerTest() {
 
 
         if (sentRequests.size > 0) {
-            sentRequests[1] `should be instance of` MailboxRequest.LoadEmailThreads::class.java
+            sentRequests.forEach {
+                it `should not be instance of` MailboxRequest.LoadEmailThreads::class.java
+            }
         }
     }
 }


### PR DESCRIPTION
- On pressing and action button on the push notification you no longer need to wait until the operation has completed to see the notification go away.
- After entering and exiting from an email detail, the mailbox took you to the top, this no longer is the case.