### PR TITLE
Various fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 48
-        versionName "0.16.6"
+        versionCode 49
+        versionName "0.16.7"
         applicationId "com.criptext.mail"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/src/main/kotlin/com/criptext/mail/ExternalActivityParams.kt
+++ b/src/main/kotlin/com/criptext/mail/ExternalActivityParams.kt
@@ -2,9 +2,9 @@ package com.criptext.mail
 
 
 sealed class ExternalActivityParams {
-    data class FilePicker(val remaining: Int): ExternalActivityParams()
+    class FilePicker: ExternalActivityParams()
     class ProfileImagePicker: ExternalActivityParams()
-    data class ImagePicker(val remaining: Int): ExternalActivityParams()
+    class ImagePicker: ExternalActivityParams()
     data class PinScreen(val isFirstTime: Boolean): ExternalActivityParams()
     class Camera: ExternalActivityParams()
     class InviteFriend: ExternalActivityParams()

--- a/src/main/kotlin/com/criptext/mail/push/data/UpdateMailboxWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/push/data/UpdateMailboxWorker.kt
@@ -96,11 +96,15 @@ class UpdateMailboxWorker(
                         newData["name"] = dbEvents.getFromContactByEmailId(email.id)[0].name
                         newData["email"] = dbEvents.getFromContactByEmailId(email.id)[0].email
                         val emailAddress = newData["email"]
-                        val bm = if(emailAddress != null && EmailAddressUtils.isFromCriptextDomain(emailAddress))
+                        val bm = try {
+                            if(emailAddress != null && EmailAddressUtils.isFromCriptextDomain(emailAddress))
                                 Picasso.get().load(Hosts.restApiBaseUrl
-                                .plus("/user/avatar/${EmailAddressUtils.extractRecipientIdFromCriptextAddress(emailAddress)}")).get()
-                        else
+                                        .plus("/user/avatar/${EmailAddressUtils.extractRecipientIdFromCriptextAddress(emailAddress)}")).get()
+                            else
+                                null
+                        } catch (ex: Exception){
                             null
+                        }
 
                         if(shouldCallAgain) {
                             PushResult.UpdateMailbox.SuccessAndRepeat(

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerActivity.kt
@@ -87,22 +87,17 @@ class ComposerActivity : BaseActivity() {
                                 setActivityMessage(ActivityMessage.AddAttachments(listOf(attachment)))
                         }
                     }else{
-                        val remaining = data.getIntExtra("remaining", 0)
-                        if(clipData.itemCount < remaining) {
-                            val attachmentList = mutableListOf<Pair<String, Long>>()
-                            for (i in 0 until clipData.itemCount) {
-                                clipData.getItemAt(i).also { item ->
-                                    val attachment = FileUtils.getPathAndSizeFromUri(item.uri, contentResolver,
-                                            this)
-                                    if (attachment != null)
-                                        attachmentList.add(attachment)
-                                }
+                        val attachmentList = mutableListOf<Pair<String, Long>>()
+                        for (i in 0 until clipData.itemCount) {
+                            clipData.getItemAt(i).also { item ->
+                                val attachment = FileUtils.getPathAndSizeFromUri(item.uri, contentResolver,
+                                        this)
+                                if (attachment != null)
+                                    attachmentList.add(attachment)
                             }
-                            if (attachmentList.isNotEmpty())
-                                setActivityMessage(ActivityMessage.AddAttachments(attachmentList))
-                        }else{
-                            setActivityMessage(ActivityMessage.ShowUIMessage(UIMessage(R.string.too_many_files)))
                         }
+                        if (attachmentList.isNotEmpty())
+                            setActivityMessage(ActivityMessage.AddAttachments(attachmentList))
                     }
                 }
             }

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerModel.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerModel.kt
@@ -21,6 +21,9 @@ class ComposerModel(val type: ComposerType) {
 
     var attachments: ArrayList<ComposerAttachment> = ArrayList()
 
+    val filesExceedingMaxEmailSize = mutableListOf<String>()
+    val filesExceedingMaxFileSize = mutableListOf<Pair<String, String>>()
+
     var isUploadingAttachments = false
 
     val to = LinkedList<Contact>()

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerScene.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerScene.kt
@@ -280,7 +280,7 @@ interface ComposerScene {
         override fun showMaxFilesExceedsDialog(){
             val builder = AlertDialog.Builder(ctx)
             val size = FileUtils.readableFileSize(EmailUtils.ATTACHMENT_SIZE_LIMIT.toLong(), 1000)
-            builder.setTitle(ctx.resources.getString(R.string.error_attach_file))
+            builder.setTitle(ctx.resources.getString(R.string.error_email_max_files_title))
                     .setMessage(ctx.resources.getString(R.string.error_email_max_size, size))
                     .show()
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailActivity.kt
@@ -113,9 +113,11 @@ class  EmailDetailActivity: BaseActivity() {
         when (result.type) {
             WebView.HitTestResult.IMAGE_TYPE,
             WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE -> {
-                val inflater = menuInflater
-                inflater.inflate(R.menu.web_view_image_menu, menu)
-                (controller as EmailDetailSceneController).onCreateContextMenu(result.extra)
+                if(result.extra != null && result.extra!!.startsWith("file://")) {
+                    val inflater = menuInflater
+                    inflater.inflate(R.menu.web_view_image_menu, menu)
+                    (controller as EmailDetailSceneController).onCreateContextMenu(result.extra)
+                }
             }
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/FullEmailListAdapter.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/FullEmailListAdapter.kt
@@ -159,6 +159,10 @@ class FullEmailListAdapter(private val mContext : Context,
         return if(isExpanded) fullEmails.size + 2 else MAX_SIZE_FOR_COLLAPSE
     }
 
+    fun getEmailsSize(): Int{
+        return fullEmails.size
+    }
+
     override fun getItemId(position: Int): Long {
         if(isPositionFooter(position)) {
             return -1

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/holders/FullEmailHolder.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/ui/holders/FullEmailHolder.kt
@@ -101,7 +101,7 @@ class FullEmailHolder(view: View) : ParentEmailHolder(view) {
 
         showStartGuideMenu(emailListener, fullEmail)
 
-        setAttachments(fileDetails, emailListener)
+        setAttachments(fileDetails, emailListener, adapter)
 
         emailListener?.contextMenuRegister(bodyWebView)
 
@@ -277,13 +277,22 @@ class FullEmailHolder(view: View) : ParentEmailHolder(view) {
         setIcons(fullEmail.email.delivered)
     }
 
-    private fun setAttachments(files: List<FileDetail>, emailListener: FullEmailListAdapter.OnFullEmailEventListener?){
+    private fun setAttachments(files: List<FileDetail>, emailListener: FullEmailListAdapter.OnFullEmailEventListener?,
+                               fullEmailListAdapter: FullEmailListAdapter){
         val nonInlineFiles = files.filter { it.file.cid == null }
         val adapter = FileListAdapter(view.context, nonInlineFiles)
         val mLayoutManager = LinearLayoutManager(view.context)
         adapter.observer = object: AttachmentViewObserver {
             override fun onAttachmentViewClick(position: Int) {
-                emailListener?.onAttachmentSelected(adapterPosition - 1, position)
+                val emailPosition = if(!fullEmailListAdapter.isExpanded) {
+                    if(adapterPosition == 1)
+                        adapterPosition - 1
+                    else
+                        fullEmailListAdapter.getEmailsSize() - 1
+                } else {
+                    adapterPosition - 1
+                }
+                emailListener?.onAttachmentSelected(emailPosition, position)
             }
             override fun onRemoveAttachmentClicked(position: Int) {}
         }

--- a/src/main/kotlin/com/criptext/mail/scenes/params/SettingsParams.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/params/SettingsParams.kt
@@ -2,6 +2,6 @@ package com.criptext.mail.scenes.params
 
 import com.criptext.mail.scenes.settings.SettingsActivity
 
-class SettingsParams: SceneParams(){
+class SettingsParams(val hasChangedTheme: Boolean = false): SceneParams(){
     override val activityClass = SettingsActivity::class.java
 }

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsController.kt
@@ -112,6 +112,7 @@ class SettingsController(
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
                 host.setAppTheme(R.style.AppTheme)
             }
+            host.exitToScene(SettingsParams(true), null, false, true)
         }
 
         override fun onResendDeviceLinkAuth() {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsModel.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsModel.kt
@@ -4,7 +4,7 @@ import com.criptext.mail.scenes.label_chooser.data.LabelWrapper
 import com.criptext.mail.scenes.settings.devices.DeviceItem
 import com.criptext.mail.validation.FormInputState
 
-class SettingsModel{
+class SettingsModel(var hasChangedTheme: Boolean = false){
     var fullName: String = ""
     var signature: String = ""
     val labels : ArrayList<LabelWrapper> = ArrayList()
@@ -20,7 +20,6 @@ class SettingsModel{
     var hasReadReceipts: Boolean = false
     var recoveryEmail: String = ""
     var replyToEmail: String? = null
-    var hasChangedTheme: Boolean = false
 
     var isWaitingForSync = false
 

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsScene.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/SettingsScene.kt
@@ -61,6 +61,7 @@ interface SettingsScene{
     fun dismissSyncBeginDialog()
     fun dismissReplyToEmailDialog()
     fun syncBeginDialogDenied()
+    fun clearThemeSwitchListener()
 
 
     var settingsUIObserver: SettingsUIObserver?
@@ -271,6 +272,10 @@ interface SettingsScene{
             )
             if(model.devices.size == 1)
                 generalView.enable2FASwitch(true)
+        }
+
+        override fun clearThemeSwitchListener() {
+            generalView.disableDarkThemeSwitch()
         }
 
         override fun enableTwoFASwitch(isEnabled: Boolean) {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/views/GeneralSettingsView.kt
@@ -90,6 +90,10 @@ class GeneralSettingsView(view: View, title: String): TabView(view, title) {
         setSwitchListener()
     }
 
+    fun disableDarkThemeSwitch(){
+        darkThemeSwitch.setOnCheckedChangeListener { _, _ ->  }
+    }
+
     fun setDarkTheme(hasDarkTheme: Boolean){
         darkThemeSwitch.setOnCheckedChangeListener { _, _ ->  }
         darkThemeSwitch.isChecked = hasDarkTheme

--- a/src/main/kotlin/com/criptext/mail/utils/Utility.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/Utility.kt
@@ -110,6 +110,7 @@ class Utility {
 
         private fun getAvatarLetters(fullName: String): String{
             val cleanedName = fullName.trim()
+            if(cleanedName.isEmpty()) return ""
             val firstLetter = cleanedName.toCharArray()[0].toString().toUpperCase()
             val secondLetter = if(cleanedName.contains(" "))
                 cleanedName[cleanedName.lastIndexOf(" ") + 1].toString().toUpperCase()

--- a/src/main/kotlin/com/criptext/mail/utils/generaldatasource/workers/GetRemoteFileWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/generaldatasource/workers/GetRemoteFileWorker.kt
@@ -11,6 +11,7 @@ import com.criptext.mail.bgworker.BackgroundWorker
 import com.criptext.mail.bgworker.ProgressReporter
 import com.criptext.mail.scenes.composer.data.ComposerResult
 import com.criptext.mail.utils.UIMessage
+import com.criptext.mail.utils.file.FileUtils
 import com.criptext.mail.utils.generaldatasource.data.GeneralResult
 import org.json.JSONException
 import java.io.File
@@ -42,7 +43,10 @@ class GetRemoteFileWorker(private val uris: List<String>,
                 it.moveToFirst()
                 it.getString(nameIndex)
             }
-            val file = createTempFile(prefix = name ?: "tmp", suffix = ".".plus(extension))
+
+            var cleanedName = if(name == null) null else FileUtils.getBasenameAndExtension(name).first
+            if(cleanedName != null && cleanedName.length < 3) cleanedName = cleanedName.plus("_tmp")
+            val file = createTempFile(prefix = cleanedName ?: "tmp", suffix = ".".plus(extension))
 
             val stream = contentResolver.openInputStream(realUri)
             stream.use { input ->

--- a/src/main/kotlin/com/criptext/mail/utils/ui/MessageAndProgressDialog.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/ui/MessageAndProgressDialog.kt
@@ -8,6 +8,7 @@ import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.criptext.mail.BaseActivity
 import com.criptext.mail.R
 import com.criptext.mail.utils.UIMessage
 import com.criptext.mail.utils.getLocalizedUIMessage
@@ -20,7 +21,7 @@ class MessageAndProgressDialog(val context: Context, val message: UIMessage) {
     fun showDialog() {
 
         val dialogBuilder = AlertDialog.Builder(context)
-        val inflater = (context as AppCompatActivity).layoutInflater
+        val inflater = (context as BaseActivity).layoutInflater
         val dialogView = inflater.inflate(R.layout.message_and_progress_dialog, null)
 
         dialogBuilder.setView(dialogView)

--- a/src/main/res/layout/settings_2_fa_enable_dialog.xml
+++ b/src/main/res/layout/settings_2_fa_enable_dialog.xml
@@ -42,7 +42,7 @@
         android:paddingBottom="15dp"
         android:paddingEnd="15dp"
         android:paddingStart="15dp"
-        android:textColor="@color/textColorPrimary"
+        android:textColor="?attr/criptextSecondaryTextColor"
         android:visibility="gone"
         android:textSize="15sp"/>
 

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -457,4 +457,5 @@
   <string name="profile_picture_deleted">Tu imagen de perfil ha sido borrada</string>
   <string name="profile_picture_delete_failed">Imagen de perfil no se pudo borrar</string>
   <string name="change_name_btn_text">Cambiar Nombre</string>
+  <string name="error_email_max_files_title">Capacidad Máxima</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -457,4 +457,5 @@
   <string name="profile_picture_deleted">Profile picture deleted successfully</string>
   <string name="profile_picture_delete_failed">Error on deleting profile picture</string>
   <string name="change_name_btn_text">Edit Name</string>
+  <string name="error_email_max_files_title">Files Capacity</string>
 </resources>


### PR DESCRIPTION
- Weird bug that happened in some devices that could not init the controller for some reason, now we restart the app when this fails.
- Fixed bug that happened when you activated Dark Theme, and made the settings screen disappear.
- Removed limitations for file quantity when attaching files.
- Now only one dialog will pop up when file size is exceeded when composing an email.
- Fixed error when trying to download an attachment on a collapsed thread.
- Fixed an error when Picasso tried to load images on push notifications.
- Fixed a weird case in which getting the avatar letters form an empty name.
- Fixed a weird error when attaching a remote file, that picked the name in a weird way.