### PR TITLE
Now sending file keys for externals and also avoiding unsend on peer issue.

### DIFF
--- a/src/androidTest/kotlin/com/criptext/mail/mocks/MockJSONData.kt
+++ b/src/androidTest/kotlin/com/criptext/mail/mocks/MockJSONData.kt
@@ -26,12 +26,12 @@ object MockJSONData {
             "rowid": 4,
             "cmd": 101,
             "params":
-                "{\"threadId\":\"<15221916.12518@criptext.com>\",\"subject\":\"hello\",\"from\":\"Mayer Mizrachi <mayer@criptext.com>\",\"to\":\"gabriel@criptext.com\",\"cc\":\"\",\"bcc\":\"\",\"messageId\":\"<15221916.12518@criptext.com>\",\"date\":\"2018-03-27 23:00:13\",\"metadataKey\":81,\"messageType\":3,\"senderDeviceId\":1}"
+                "{\"threadId\":\"<15221916.12518@criptext.com>\",\"subject\":\"hello\",\"from\":\"Mayer Mizrachi <mayer@criptext.com>\",\"to\":\"gabriel@criptext.com\",\"cc\":\"\",\"bcc\":\"\",\"messageId\":\"<15221916.12518@criptext.com>\",\"date\":\"2018-03-27 23:00:13\",\"metadataKey\":81,\"messageType\":3,\"senderDeviceId\":1,\"guestEncryption\":1}"
 },{
             "rowid": 5,
             "cmd": 101,
             "params":
-                "{\"threadId\":\"<15221916.12519@criptext.com>\",\"subject\":\"hello again\",\"from\":\"Gianni Carlo <gianni@criptext.com>\",\"to\":\"gabriel@criptext.com\",\"cc\":\"\",\"bcc\":\"\",\"messageId\":\"<15221916.12519@criptext.com>\",\"date\":\"2018-03-27 23:00:13\",\"metadataKey\":82,\"messageType\":3,\"senderDeviceId\":1}"
+                "{\"threadId\":\"<15221916.12519@criptext.com>\",\"subject\":\"hello again\",\"from\":\"Gianni Carlo <gianni@criptext.com>\",\"to\":\"gabriel@criptext.com\",\"cc\":\"\",\"bcc\":\"\",\"messageId\":\"<15221916.12519@criptext.com>\",\"date\":\"2018-03-27 23:00:13\",\"metadataKey\":82,\"messageType\":3,\"senderDeviceId\":1,\"guestEncryption\":1}"
 }
 ]"""
     val sample2TrackingUpdateEvents = """

--- a/src/androidTest/kotlin/com/criptext/mail/scenes/emaildetail/data/UnsendEmailWorkerTest.kt
+++ b/src/androidTest/kotlin/com/criptext/mail/scenes/emaildetail/data/UnsendEmailWorkerTest.kt
@@ -1,0 +1,118 @@
+package com.criptext.mail.scenes.emaildetail.data
+
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import com.criptext.mail.androidtest.TestActivity
+import com.criptext.mail.androidtest.TestDatabase
+import com.criptext.mail.androidtest.TestSharedPrefs
+import com.criptext.mail.api.HttpClient
+import com.criptext.mail.db.*
+import com.criptext.mail.db.models.Account
+import com.criptext.mail.db.models.ActiveAccount
+import com.criptext.mail.db.models.Contact
+import com.criptext.mail.db.models.Label
+import com.criptext.mail.mocks.MockEmailData
+import com.criptext.mail.scenes.composer.data.ComposerAttachment
+import com.criptext.mail.scenes.composer.data.ComposerInputData
+import com.criptext.mail.scenes.composer.data.ComposerResult
+import com.criptext.mail.scenes.composer.workers.SaveEmailWorker
+import com.criptext.mail.scenes.emaildetail.workers.UnsendFullEmailWorker
+import com.criptext.mail.scenes.mailbox.workers.SendMailWorker
+import com.criptext.mail.signal.*
+import com.criptext.mail.utils.*
+import io.mockk.mockk
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldNotBe
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.rules.TemporaryFolder
+
+
+@RunWith(AndroidJUnit4::class)
+class UnsendEmailWorkerTest {
+    @get:Rule
+    val mActivityRule = ActivityTestRule(TestActivity::class.java)
+
+    private lateinit var storage: KeyValueStorage
+    private lateinit var db: TestDatabase
+    private lateinit var emailDetailLocalDB: EmailDetailLocalDB
+    private lateinit var signalClient: SignalClient
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var httpClient: HttpClient
+
+    private val keyGenerator = SignalKeyGenerator.Default(DeviceUtils.DeviceType.Android)
+    private val activeAccount = ActiveAccount(name = "Tester", recipientId = "tester",
+            deviceId = 1, jwt = "__JWTOKEN__", signature = "", refreshToken = "")
+    @Before
+    fun setup() {
+        db = TestDatabase.getInstance(mActivityRule.activity)
+        db.resetDao().deleteAllData(1)
+
+        db.labelDao().insertAll(Label.DefaultItems().toList())
+        db.accountDao().insert(Account(activeAccount.recipientId, activeAccount.deviceId,
+                activeAccount.name, activeAccount.jwt, activeAccount.refreshToken,
+                "_KEY_PAIR_", 0, ""))
+        emailDetailLocalDB = EmailDetailLocalDB.Default(db, mActivityRule.activity.filesDir)
+        storage = mockk(relaxed = true)
+        MockEmailData.insertEmailsNeededForTests(db, listOf(Label.defaultItems.inbox),
+                mActivityRule.activity.filesDir, activeAccount.recipientId)
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        val mockWebServerUrl = mockWebServer.url("/mock").toString()
+        httpClient = HttpClient.Default(authScheme = HttpClient.AuthScheme.jwt,
+                baseUrl = mockWebServerUrl, connectionTimeout = 1000L, readTimeout = 1000L)
+    }
+
+    private fun newWorker(emailId: Long, position: Int): UnsendFullEmailWorker =
+            UnsendFullEmailWorker(db = emailDetailLocalDB, emailDao = db.emailDao(),
+                    emailContactDao = db.emailContactDao(), emailId = emailId, position = position,
+                    accountDao = db.accountDao(), storage = storage, httpClient = httpClient,
+                    activeAccount = activeAccount, publishFn = {})
+
+    @Test
+    fun should_delete_email_content_on_unsend() {
+
+        mockWebServer.enqueueResponses(listOf(
+                MockedResponse.Ok("Ok")
+        ))
+
+        val emails = db.emailDao().getAll()
+        val emailToUnsend = emails[0]
+
+        val emailContentBeforeUnsend = EmailUtils.getEmailContentFromFileSystem(
+                dbContent = emailToUnsend.content,
+                filesDir = mActivityRule.activity.filesDir,
+                metadataKey = emailToUnsend.metadataKey,
+                recipientId = activeAccount.recipientId
+        )
+
+        emailContentBeforeUnsend.first shouldNotBeEqualTo ""
+
+
+        val worker = newWorker(emailToUnsend.id, 0)
+        worker.work(mockk(relaxed = true))
+                as EmailDetailResult.UnsendFullEmailFromEmailId.Success
+
+        val unsentEmailFromDB = db.emailDao().getEmailById(emailToUnsend.id)
+
+        unsentEmailFromDB shouldNotBe null
+
+        val emailContentAfterUnsend = EmailUtils.getEmailContentFromFileSystem(
+                dbContent = unsentEmailFromDB!!.content,
+                filesDir = mActivityRule.activity.filesDir,
+                metadataKey = unsentEmailFromDB.metadataKey,
+                recipientId = activeAccount.recipientId
+        )
+
+        emailContentAfterUnsend.first shouldEqual ""
+
+    }
+
+}

--- a/src/main/kotlin/com/criptext/mail/api/models/EmailMetadata.kt
+++ b/src/main/kotlin/com/criptext/mail/api/models/EmailMetadata.kt
@@ -39,7 +39,7 @@ data class EmailMetadata(
     fun extractDBColumns(): DBColumns =
             DBColumns(to = to, cc = cc, bcc = bcc, messageId = messageId, threadId = threadId,
                     metadataKey = metadataKey, subject = subject, date = date, unsentDate = null,
-                    fromContact = fromContact, unread = true, status = DeliveryTypes.NONE, secure = true,
+                    fromContact = fromContact, unread = true, status = DeliveryTypes.NONE, secure = secure,
                     trashDate = null, replyTo = replyTo, boundary = boundary)
 
     companion object {
@@ -59,6 +59,9 @@ data class EmailMetadata(
             val senderDeviceId = emailData.optInt("senderDeviceId")
             val files = CRFile.listFromJSON(metadataJsonString)
             val fileKey = getFileKey(metadataJsonString)
+            val guestEncryption = emailData.getInt("guestEncryption")
+            val secure = guestEncryption == 1 || guestEncryption == 3
+
             return EmailMetadata(
                     from = from,
                     senderRecipientId = fromRecipientId,
@@ -77,7 +80,7 @@ data class EmailMetadata(
                     messageType = SignalEncryptedData.Type.fromInt(messageType),
                     files = files,
                     fileKey = fileKey.key,
-                    secure = true,
+                    secure = secure,
                     isSpam = checkSpam(emailData),
                     isExternal = isExternal
             )

--- a/src/main/kotlin/com/criptext/mail/db/MailboxLocalDB.kt
+++ b/src/main/kotlin/com/criptext/mail/db/MailboxLocalDB.kt
@@ -449,7 +449,7 @@ interface MailboxLocalDB {
             val fromContact = if(EmailAddressUtils.checkIfOnlyHasEmail(email.fromAddress)){
                 contactsFROM[0]
             }else Contact(
-                    id = 0,
+                    id = contactsFROM[0].id,
                     email = EmailAddressUtils.extractEmailAddress(email.fromAddress),
                     name = EmailAddressUtils.extractName(email.fromAddress),
                     isTrusted = contactsFROM[0].isTrusted,

--- a/src/main/kotlin/com/criptext/mail/db/SearchLocalDB.kt
+++ b/src/main/kotlin/com/criptext/mail/db/SearchLocalDB.kt
@@ -92,7 +92,7 @@ interface SearchLocalDB{
             val fromContact = if(EmailAddressUtils.checkIfOnlyHasEmail(email.fromAddress)){
                 contactsFROM[0]
             }else Contact(
-                    id = 0,
+                    id = contactsFROM[0].id,
                     email = EmailAddressUtils.extractEmailAddress(email.fromAddress),
                     name = EmailAddressUtils.extractName(email.fromAddress),
                     isTrusted = contactsFROM[0].isTrusted,

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/ThreadListController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/ThreadListController.kt
@@ -22,7 +22,8 @@ class ThreadListController(private val model : MailboxSceneModel,
     }
 
     fun appendAll(loadedThreads : List<EmailPreview>, hasReachedEnd: Boolean) {
-        model.threads.addAll(loadedThreads)
+        val threadsToAppend = loadedThreads.filter { !model.threads.contains(it) }
+        model.threads.addAll(threadsToAppend)
 
         model.hasReachedEnd = hasReachedEnd
         virtualListView?.notifyDataSetChanged()

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/workers/SendMailWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/workers/SendMailWorker.kt
@@ -27,6 +27,7 @@ import com.criptext.mail.utils.file.FileUtils
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.mapError
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.File
@@ -370,6 +371,7 @@ class SendMailWorker(private val signalClient: SignalClient,
         jsonSignedPreKey.put("privateKey", Encoding.byteArrayToString(signedPreKey.keyPair.privateKey.serialize()))
         jsonReturn.put("signedPreKey", jsonSignedPreKey)
         jsonReturn.put("fileKey", fileKey)
+        jsonReturn.put("fileKeys", JSONArray(getFileKeys()))
         return jsonReturn
     }
 


### PR DESCRIPTION
- Added two more tests for AES Utils
- Added a test for unsending emails
- Secure property of email is now correctly assigned so that peer devices have the correct information.
- Scrolling down on your mailbox won't show the same thread twice.
- Now we are sending fileKeys to external emails.