### PR TITLE
Fixes to external storage file picking. Various Optimizations and fixes.

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/Android-Email-Client.iml" filepath="$PROJECT_DIR$/.idea/Android-Email-Client.iml" />
-      <module fileurl="file://$PROJECT_DIR$/Android-Email-Client.iml" filepath="$PROJECT_DIR$/Android-Email-Client.iml" />
     </modules>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 80
-        versionName "0.21.4"
+        versionCode 81
+        versionName "0.21.5"
         applicationId "com.criptext.mail"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/src/androidTest/kotlin/com/criptext/mail/scenes/composer/data/LoadInitialDataWorkerTest.kt
+++ b/src/androidTest/kotlin/com/criptext/mail/scenes/composer/data/LoadInitialDataWorkerTest.kt
@@ -74,7 +74,7 @@ class LoadInitialDataWorkerTest {
     private fun newWorker(emailId: Long, type: ComposerType): LoadInitialDataWorker =
             LoadInitialDataWorker(db = composerLocalDB, emailId = emailId, composerType = type,
                     userEmailAddress = activeAccount.userEmail, signature = activeAccount.signature,
-                    publishFn = {}, activeAccount = activeAccount)
+                    publishFn = {}, activeAccount = activeAccount, httpClient = mockk())
 
     private fun insertEmailToLoad(to: List<Contact>, fromContact: Contact, subject: String,
                                   decryptedBody: String, isDraft: Boolean, fileKey: String?, accountId: Long): Long {

--- a/src/main/kotlin/com/criptext/mail/api/PeerEventsApiHandler.kt
+++ b/src/main/kotlin/com/criptext/mail/api/PeerEventsApiHandler.kt
@@ -78,4 +78,7 @@ interface PeerEventsApiHandler {
             }
         }
     }
+    companion object {
+        const val BATCH_SIZE = 50;
+    }
 }

--- a/src/main/kotlin/com/criptext/mail/db/dao/EmailDao.kt
+++ b/src/main/kotlin/com/criptext/mail/db/dao/EmailDao.kt
@@ -237,7 +237,7 @@ import java.util.*
             left join email_label on email.id = email_label.emailId
             where email_label.labelId=:labelId AND email.accountId = :accountId
             AND (julianday('now') - julianday(email.trashDate)) >= 30""")
-    fun getTrashExpiredThreadIds(labelId: Long, accountId: Long): List<Long>
+    fun getTrashExpiredEmailIds(labelId: Long, accountId: Long): List<Long>
 
     @Query("""UPDATE email
             SET trashDate=:trashDate

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/ComposerController.kt
@@ -441,11 +441,23 @@ class ComposerController(private val storage: KeyValueStorage,
 
     private fun updateModelWithInputData(data: ComposerInputData) {
         model.to.clear()
-        model.to.addAll(data.to.map { Contact(it.id, it.email.toLowerCase(), it.name, it.isTrusted, it.score, it.spamScore) })
+        model.to.addAll(data.to.map {
+            val contact = Contact(it.id, it.email.toLowerCase(), it.name, it.isTrusted, it.score, it.spamScore)
+            contact.isCriptextDomain = it.isCriptextDomain
+            contact
+        })
         model.cc.clear()
-        model.cc.addAll(data.cc.map { Contact(it.id, it.email.toLowerCase(), it.name, it.isTrusted, it.score, it.spamScore) })
+        model.cc.addAll(data.cc.map {
+            val contact = Contact(it.id, it.email.toLowerCase(), it.name, it.isTrusted, it.score, it.spamScore)
+            contact.isCriptextDomain = it.isCriptextDomain
+            contact
+        })
         model.bcc.clear()
-        model.bcc.addAll(data.bcc.map { Contact(it.id, it.email.toLowerCase(), it.name, it.isTrusted, it.score, it.spamScore) })
+        model.bcc.addAll(data.bcc.map {
+            val contact = Contact(it.id, it.email.toLowerCase(), it.name, it.isTrusted, it.score, it.spamScore)
+            contact.isCriptextDomain = it.isCriptextDomain
+            contact
+        })
         model.body = data.body
         model.subject = data.subject
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/composer/data/ComposerDataSource.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/composer/data/ComposerDataSource.kt
@@ -53,7 +53,9 @@ class ComposerDataSource(
                     httpClient = httpClient, activeAccount = activeAccount,
                     publishFn = { res -> flushResults(res) }, fileKey = params.fileKey,
                     accountDao = composerLocalDB.accountDao, storage = storage)
-            is ComposerRequest.LoadInitialData -> LoadInitialDataWorker(db = composerLocalDB,
+            is ComposerRequest.LoadInitialData -> LoadInitialDataWorker(
+                    httpClient = HttpClient.Default(),
+                    db = composerLocalDB,
                     emailId = params.emailId,
                     composerType = params.composerType,
                     userEmailAddress = activeAccount.userEmail,

--- a/src/main/kotlin/com/criptext/mail/scenes/mailbox/workers/EmptyTrashWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/mailbox/workers/EmptyTrashWorker.kt
@@ -15,6 +15,7 @@ import com.criptext.mail.db.models.Label
 import com.criptext.mail.scenes.mailbox.data.MailboxResult
 import com.criptext.mail.utils.ServerCodes
 import com.criptext.mail.utils.UIMessage
+import com.criptext.mail.utils.batch
 import com.criptext.mail.utils.peerdata.PeerDeleteEmailData
 import com.github.kittinunf.result.Result
 
@@ -53,7 +54,9 @@ class EmptyTrashWorker(
 
         return when (result) {
             is Result.Success -> {
-                peerEventHandler.enqueueEvent(PeerDeleteEmailData(metadataKeys).toJSON())
+                metadataKeys.asSequence().batch(PeerEventsApiHandler.BATCH_SIZE).forEach { batch ->
+                    peerEventHandler.enqueueEvent(PeerDeleteEmailData(batch).toJSON())
+                }
                 MailboxResult.EmptyTrash.Success()
             }
             is Result.Failure -> {

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/profile/ProfileController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/profile/ProfileController.kt
@@ -441,7 +441,7 @@ class ProfileController(
             is ProfileResult.SetProfilePicture.Failure -> {
                 scene.resetProfilePicture(model.userData.name)
                 scene.hideProfilePictureProgress()
-                scene.showMessage(UIMessage(R.string.profile_picture_update_failed))
+                scene.showMessage(result.message)
             }
             is ProfileResult.SetProfilePicture.EnterpriseSuspended -> {
                 showSuspendedAccountDialog()
@@ -457,7 +457,7 @@ class ProfileController(
                 scene.showMessage(UIMessage(R.string.profile_picture_deleted))
             }
             is ProfileResult.DeleteProfilePicture.Failure -> {
-                scene.showMessage(UIMessage(R.string.profile_picture_delete_failed))
+                scene.showMessage(result.message)
             }
             is ProfileResult.DeleteProfilePicture.EnterpriseSuspended -> {
                 showSuspendedAccountDialog()

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/profile/workers/DeleteProfilePictureWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/profile/workers/DeleteProfilePictureWorker.kt
@@ -37,7 +37,7 @@ class DeleteProfilePictureWorker(val httpClient: HttpClient,
                 else -> ProfileResult.DeleteProfilePicture.Failure(UIMessage(R.string.server_bad_status, arrayOf(ex.errorCode)), ex)
             }
         }else {
-            ProfileResult.DeleteProfilePicture.Failure(UIMessage(R.string.server_error_exception), ex)
+            ProfileResult.DeleteProfilePicture.Failure(UIMessage(R.string.server_error_exception, arrayOf(ex.toString())), ex)
         }
     }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/profile/workers/SetProfilePictureWorker.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/profile/workers/SetProfilePictureWorker.kt
@@ -47,7 +47,7 @@ class SetProfilePictureWorker(val httpClient: HttpClient,
                 else -> ProfileResult.SetProfilePicture.Failure(UIMessage(R.string.server_bad_status, arrayOf(ex.errorCode)), ex)
             }
         }else {
-            ProfileResult.SetProfilePicture.Failure(UIMessage(R.string.server_error_exception), ex)
+            ProfileResult.SetProfilePicture.Failure(UIMessage(R.string.unknown_error, arrayOf(ex.toString())), ex)
         }
     }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/settings/recovery_email/data/RecoveryEmailAPIClient.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/settings/recovery_email/data/RecoveryEmailAPIClient.kt
@@ -10,7 +10,8 @@ class RecoveryEmailAPIClient(private val httpClient: HttpClient, var token: Stri
 
     fun putChangeReplyToEmail(email: String, enabled: Boolean): HttpResponseData {
         val json = JSONObject()
-        json.put("address", email)
+        if(enabled)
+            json.put("address", email)
         json.put("enable", enabled)
         return httpClient.put(path = "/user/replyto", authToken = token, body = json)
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
@@ -1,5 +1,6 @@
 package com.criptext.mail.scenes.signin
 
+import com.criptext.mail.BuildConfig
 import com.criptext.mail.ExternalActivityParams
 import com.criptext.mail.IHostActivity
 import com.criptext.mail.R
@@ -680,7 +681,7 @@ class SignInSceneController(
         }
 
         override fun onContactSupportPressed() {
-            host.launchExternalActivityForResult(ExternalActivityParams.GoToCriptextUrl("contact"))
+            host.launchExternalActivityForResult(ExternalActivityParams.GoToCriptextUrl("contact?version=${BuildConfig.VERSION_NAME}&device=${DeviceUtils.getDeviceName()}&os=${DeviceUtils.getDeviceOS()}"))
         }
 
         override fun onSubmitButtonClicked() {

--- a/src/main/kotlin/com/criptext/mail/scenes/signup/SignUpSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signup/SignUpSceneController.kt
@@ -1,10 +1,7 @@
 package com.criptext.mail.scenes.signup
 
 import android.content.Intent
-import com.criptext.mail.BaseActivity
-import com.criptext.mail.ExternalActivityParams
-import com.criptext.mail.IHostActivity
-import com.criptext.mail.R
+import com.criptext.mail.*
 import com.criptext.mail.api.ServerErrorException
 import com.criptext.mail.bgworker.BackgroundWorkManager
 import com.criptext.mail.bgworker.RunnableThrottler
@@ -15,10 +12,7 @@ import com.criptext.mail.scenes.params.MailboxParams
 import com.criptext.mail.scenes.params.SignInParams
 import com.criptext.mail.scenes.signup.data.SignUpRequest
 import com.criptext.mail.scenes.signup.data.SignUpResult
-import com.criptext.mail.utils.KeyboardManager
-import com.criptext.mail.utils.ServerCodes
-import com.criptext.mail.utils.UIMessage
-import com.criptext.mail.utils.sha256
+import com.criptext.mail.utils.*
 import com.criptext.mail.validation.AccountDataValidator
 import com.criptext.mail.validation.FormData
 import com.criptext.mail.validation.FormInputState
@@ -155,7 +149,7 @@ class SignUpSceneController(
         }
 
         override fun onContactSupportClick() {
-            host.launchExternalActivityForResult(ExternalActivityParams.GoToCriptextUrl("contact"))
+            host.launchExternalActivityForResult(ExternalActivityParams.GoToCriptextUrl("contact?version=${BuildConfig.VERSION_NAME}&device=${DeviceUtils.getDeviceName()}&os=${DeviceUtils.getDeviceOS()}"))
         }
 
         private fun checkPasswords(passwords: Pair<String, String>) {

--- a/src/main/kotlin/com/criptext/mail/utils/file/PathUtil.kt
+++ b/src/main/kotlin/com/criptext/mail/utils/file/PathUtil.kt
@@ -35,7 +35,11 @@ object PathUtil {
                 isExternalStorageDocument(uri) -> {
                     val docId = DocumentsContract.getDocumentId(uri)
                     val split = docId.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-                    return Environment.getExternalStorageDirectory().absolutePath + "/" + split[1]
+                    return if(split[0] != "0"){
+                        "storage/${split[0]}/${split[1]}"
+                    } else {
+                        Environment.getExternalStorageDirectory().absolutePath + "/" + split[1]
+                    }
                 }
                 isDownloadsDocument(uri) -> {
                     val id = DocumentsContract.getDocumentId(uri)


### PR DESCRIPTION
- When replying or editing a draft now the recipient will show the correct color if it is a Criptext Business contact.
- Picking files from external storage is now possible.
- Now peer events are sent in batches of 50 items per event.
- Now the contact support from login sends the device information for better customer support.
- Now showing a more descriptive error for setting up a profile picture.
- Fixed a bug when removing the reply to email.