### PR TITLE
Fixed label crash and notification decryption service lingering.

### DIFF
--- a/src/main/kotlin/com/criptext/mail/BaseActivity.kt
+++ b/src/main/kotlin/com/criptext/mail/BaseActivity.kt
@@ -68,6 +68,7 @@ import com.criptext.mail.scenes.settings.syncing.SyncingModel
 import com.criptext.mail.scenes.signin.SignInActivity
 import com.criptext.mail.scenes.signin.SignInSceneModel
 import com.criptext.mail.scenes.signup.SignUpSceneModel
+import com.criptext.mail.services.DecryptionService
 import com.criptext.mail.services.MessagingInstance
 import com.criptext.mail.splash.SplashActivity
 import com.criptext.mail.utils.*
@@ -237,6 +238,9 @@ abstract class BaseActivity: PinCompatActivity(), IHostActivity {
         notificationManager.cancel(CriptextNotification.ERROR_ID)
         notificationManager.cancel(CriptextNotification.LINK_DEVICE_ID)
         notificationManager.cancel(CriptextNotification.DECRYPTION_SERVICE_ID)
+        val stopIntent = Intent(this, DecryptionService::class.java)
+        stopIntent.action = DecryptionService.ACTION_OPEN_APP
+        startService(stopIntent)
         storage.getInt(KeyValueStorage.StringKey.NewMailNotificationCount, 0)
         storage.getInt(KeyValueStorage.StringKey.SyncNotificationCount, 0)
     }

--- a/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailScene.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/emaildetail/EmailDetailScene.kt
@@ -129,11 +129,13 @@ interface EmailDetailScene {
 
         private fun getLabelsFromEmails(
                 emails: VirtualList<FullEmail>) : VirtualList<Label> {
-            val labelSet = HashSet<Label>()
-            for (i in 0 until emails.size) {
-                labelSet.addAll(emails[i].labels)
+            val labels = mutableListOf<Label>()
+            emails.forEach { email ->
+                email.labels.forEach {
+                    if(!labels.contains(it)) labels.add(it)
+                }
             }
-            val labelsList = ArrayList(labelSet).filter { it.type != LabelTypes.SYSTEM}
+            val labelsList = ArrayList(labels).filter { it.type != LabelTypes.SYSTEM}
             return VirtualList.Map(labelsList, { t->t })
         }
 

--- a/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
+++ b/src/main/kotlin/com/criptext/mail/scenes/signin/SignInSceneController.kt
@@ -1069,9 +1069,10 @@ class SignInSceneController(
 
     private val onDevicesListItemListener: DevicesListItemListener = object: DevicesListItemListener {
         override fun onDeviceCheckChanged(): Boolean {
+            val hasSpace = ((model.devices.size - model.devices.filter { it.checked }.size) <= model.maxDevices - 1)
             scene.updateMaxDevices(model.maxDevices,
-                    ((model.devices.size - model.devices.filter { it.checked }.size)
-                            - model.maxDevices) - 1)
+                    if(hasSpace) 0 else ((model.devices.size - model.devices.filter { it.checked }.size)
+                            - (model.maxDevices - 1)))
             return true
         }
 

--- a/src/main/kotlin/com/criptext/mail/services/DecryptionService.kt
+++ b/src/main/kotlin/com/criptext/mail/services/DecryptionService.kt
@@ -53,7 +53,10 @@ class DecryptionService: Service() {
                     getPushNotification()
                 }
                 ACTION_STOP_FOREGROUND_SERVICE -> stopService()
-                ACTION_OPEN_APP -> stopService()
+                ACTION_OPEN_APP -> {
+                    stopService()
+                    return START_NOT_STICKY
+                }
                 ACTION_ADD_NOTIFICATION_TO_QUEUE -> {
                     queue.add(intent.extras?.getSerializable("data") as HashMap<String, String>)
                 }


### PR DESCRIPTION
- Changed how labels are populated on Email Detail to avoid hasCode crash on some phones.
- Now when opening the app the foreground service is explicitly stopped.